### PR TITLE
Refactor Firestore usage into services + unit tests

### DIFF
--- a/src/components/AddPingasPanel.js
+++ b/src/components/AddPingasPanel.js
@@ -1,14 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { db } from '../firebase';
-import {
-  collection,
-  query,
-  orderBy,
-  onSnapshot,
-  doc,
-  updateDoc,
-  increment,
-} from 'firebase/firestore';
+import { observeTeamsOrderedByName } from '../services/teams';
+import { addPinga } from '../services/leaderboard';
 import { toast } from 'react-toastify';
 import styles from './AddPingasPanel.module.css';
 
@@ -21,12 +13,7 @@ export default function AddPingasPanel() {
   const wrapperRef = useRef(null);
 
   // Load teams
-  useEffect(() => {
-    const q = query(collection(db, 'teams'), orderBy('name'));
-    return onSnapshot(q, (snap) => {
-      setTeams(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
-    });
-  }, []);
+  useEffect(() => observeTeamsOrderedByName(setTeams), []);
 
   // Filter suggestions
   useEffect(() => {
@@ -55,9 +42,7 @@ export default function AddPingasPanel() {
       return;
     }
     try {
-      await updateDoc(doc(db, 'teams', selectedTeam.id), {
-        pingas: increment(amount),
-      });
+      await addPinga(selectedTeam.id, amount);
       toast.success(`Adicionados ${amount} a ${selectedTeam.name}`);
       setSearch('');
       setSelectedTeam(null);

--- a/src/pages/Leaderboard.js
+++ b/src/pages/Leaderboard.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { collection, query, orderBy, onSnapshot } from 'firebase/firestore';
-import { db } from '../firebase';
+import { observeLeaderboard } from '../services/leaderboard';
 import Header from '../components/Header';
 import LeaderboardBars from '../components/LeaderboardBars';
 import SponsorsRail from '../components/SponsorsRail';
@@ -23,12 +22,7 @@ import s12 from '../assets/s12.png';
 export default function Leaderboard() {
   const [teams, setTeams] = useState([]);
 
-  useEffect(() => {
-    const q = query(collection(db, 'teams'), orderBy('pingas', 'desc'), orderBy('name'));
-    return onSnapshot(q, (snap) => {
-      setTeams(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
-    });
-  }, []);
+  useEffect(() => observeLeaderboard(setTeams), []);
 
   const left = [s1, s3, s5, s7, s10, s11];
   const right = [s2, s4, s6, s8, s9, s12];

--- a/src/services/__tests__/leaderboard.test.js
+++ b/src/services/__tests__/leaderboard.test.js
@@ -1,0 +1,91 @@
+jest.mock('../../firebase', () => ({ db: {} }));
+
+const mockCollection = jest.fn();
+const mockQuery = jest.fn();
+const mockOrderBy = jest.fn((field, dir) => ({ field, dir }));
+const mockGetDocs = jest.fn();
+const mockOnSnapshot = jest.fn();
+const mockDoc = jest.fn((db, col, id) => ({ col, id }));
+const mockUpdateDoc = jest.fn();
+const mockIncrement = jest.fn((n) => ({ __op: 'increment', n }));
+const mockLimit = jest.fn((n) => ({ __op: 'limit', n }));
+
+jest.mock('firebase/firestore', () => ({
+  collection: (...args) => mockCollection(...args),
+  query: (...args) => mockQuery(...args),
+  orderBy: (...args) => mockOrderBy(...args),
+  getDocs: (...args) => mockGetDocs(...args),
+  onSnapshot: (...args) => mockOnSnapshot(...args),
+  doc: (...args) => mockDoc(...args),
+  updateDoc: (...args) => mockUpdateDoc(...args),
+  increment: (...args) => mockIncrement(...args),
+  limit: (...args) => mockLimit(...args),
+}));
+
+describe('services/leaderboard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('getLeaderboard returns mapped teams', async () => {
+    const { getLeaderboard } = await import('../leaderboard');
+    mockGetDocs.mockResolvedValue({
+      docs: [
+        { id: 'a', data: () => ({ name: 'A', pingas: 2 }) },
+        { id: 'b', data: () => ({ name: 'B', pingas: 1 }) },
+      ],
+    });
+
+    const res = await getLeaderboard();
+    expect(mockCollection).toHaveBeenCalledWith({}, 'teams');
+    expect(mockOrderBy).toHaveBeenCalledWith('pingas', 'desc');
+    expect(res).toEqual([
+      { id: 'a', name: 'A', pingas: 2 },
+      { id: 'b', name: 'B', pingas: 1 },
+    ]);
+  });
+
+  test('observeLeaderboard calls back with mapped teams and returns unsubscribe', async () => {
+    const { observeLeaderboard } = await import('../leaderboard');
+    let internalCb;
+    mockOnSnapshot.mockImplementation((q, cb) => {
+      internalCb = cb;
+      return () => 'unsub';
+    });
+    const cb = jest.fn();
+    const unsub = observeLeaderboard(cb);
+    expect(typeof unsub).toBe('function');
+
+    // Simulate a snapshot
+    internalCb({
+      docs: [{ id: 'x', data: () => ({ name: 'X', pingas: 9 }) }],
+    });
+    expect(cb).toHaveBeenCalledWith([{ id: 'x', name: 'X', pingas: 9 }]);
+  });
+
+  test('addPinga validates delta and updates doc with increment', async () => {
+    const { addPinga } = await import('../leaderboard');
+    await addPinga('team1', 3, 'u1');
+    expect(mockDoc).toHaveBeenCalledWith({}, 'teams', 'team1');
+    expect(mockIncrement).toHaveBeenCalledWith(3);
+    expect(mockUpdateDoc).toHaveBeenCalledTimes(1);
+  });
+
+  test('addPinga throws on invalid delta', async () => {
+    const { addPinga } = await import('../leaderboard');
+    await expect(addPinga('team1', 0)).rejects.toThrow('Delta must be an integer between 1 and 5');
+    await expect(addPinga('team1', 6)).rejects.toThrow('Delta must be an integer between 1 and 5');
+  });
+
+  test('listEvents applies ordering and limit and maps docs', async () => {
+    const { listEvents } = await import('../leaderboard');
+    mockGetDocs.mockResolvedValue({
+      docs: [{ id: 'e1', data: () => ({ type: 'add', ts: 1 }) }],
+    });
+    const res = await listEvents(5);
+    expect(mockCollection).toHaveBeenCalledWith({}, 'events');
+    expect(mockOrderBy).toHaveBeenCalledWith('ts', 'desc');
+    expect(mockLimit).toHaveBeenCalledWith(5);
+    expect(res).toEqual([{ id: 'e1', type: 'add', ts: 1 }]);
+  });
+});

--- a/src/services/__tests__/teams.test.js
+++ b/src/services/__tests__/teams.test.js
@@ -1,0 +1,63 @@
+jest.mock('../../firebase', () => ({ db: {} }));
+
+const mockCollection = jest.fn();
+const mockQuery = jest.fn();
+const mockOrderBy = jest.fn((field, dir) => ({ field, dir }));
+const mockOnSnapshot = jest.fn();
+const mockWhere = jest.fn();
+const mockGetDocs = jest.fn();
+const mockAddDoc = jest.fn();
+const mockDoc = jest.fn((db, col, id) => ({ col, id }));
+const mockDeleteDoc = jest.fn();
+
+jest.mock('firebase/firestore', () => ({
+  collection: (...args) => mockCollection(...args),
+  query: (...args) => mockQuery(...args),
+  orderBy: (...args) => mockOrderBy(...args),
+  onSnapshot: (...args) => mockOnSnapshot(...args),
+  where: (...args) => mockWhere(...args),
+  getDocs: (...args) => mockGetDocs(...args),
+  addDoc: (...args) => mockAddDoc(...args),
+  doc: (...args) => mockDoc(...args),
+  deleteDoc: (...args) => mockDeleteDoc(...args),
+}));
+
+describe('services/teams', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('observeTeamsOrderedByName passes mapped teams', async () => {
+    const { observeTeamsOrderedByName } = await import('../teams');
+    let internalCb;
+    mockOnSnapshot.mockImplementation((q, cb) => {
+      internalCb = cb;
+      return () => 'unsub';
+    });
+    const cb = jest.fn();
+    const unsub = observeTeamsOrderedByName(cb);
+    expect(typeof unsub).toBe('function');
+    internalCb({ docs: [{ id: '1', data: () => ({ name: 'N', pingas: 0 }) }] });
+    expect(cb).toHaveBeenCalledWith([{ id: '1', name: 'N', pingas: 0 }]);
+  });
+
+  test('createTeamIfNotExists adds when not present', async () => {
+    const { createTeamIfNotExists } = await import('../teams');
+    mockGetDocs.mockResolvedValue({ empty: true, docs: [] });
+    await createTeamIfNotExists('New Team');
+    expect(mockAddDoc).toHaveBeenCalled();
+  });
+
+  test('createTeamIfNotExists throws when already exists', async () => {
+    const { createTeamIfNotExists } = await import('../teams');
+    mockGetDocs.mockResolvedValue({ empty: false, docs: [{}] });
+    await expect(createTeamIfNotExists('Existing')).rejects.toThrow('Team already exists');
+  });
+
+  test('deleteTeam deletes by id', async () => {
+    const { deleteTeam } = await import('../teams');
+    await deleteTeam('tid');
+    expect(mockDoc).toHaveBeenCalledWith({}, 'teams', 'tid');
+    expect(mockDeleteDoc).toHaveBeenCalled();
+  });
+});

--- a/src/services/leaderboard.js
+++ b/src/services/leaderboard.js
@@ -33,8 +33,6 @@ export async function addPinga(teamId, delta, actorUid) {
   if (!Number.isInteger(n) || n < 1 || n > 5) {
     throw new Error('Delta must be an integer between 1 and 5');
   }
-  // Log the actor performing the action for audit purposes
-  console.log(`[addPinga] actorUid=${actorUid} added ${n} pingas to teamId=${teamId}`);
   const ref = doc(db, 'teams', teamId);
   await updateDoc(ref, { pingas: increment(n) });
 }

--- a/src/services/leaderboard.js
+++ b/src/services/leaderboard.js
@@ -33,6 +33,8 @@ export async function addPinga(teamId, delta, actorUid) {
   if (!Number.isInteger(n) || n < 1 || n > 5) {
     throw new Error('Delta must be an integer between 1 and 5');
   }
+  // Log the actor performing the action for audit purposes
+  console.log(`[addPinga] actorUid=${actorUid} added ${n} pingas to teamId=${teamId}`);
   const ref = doc(db, 'teams', teamId);
   await updateDoc(ref, { pingas: increment(n) });
 }

--- a/src/services/leaderboard.js
+++ b/src/services/leaderboard.js
@@ -1,0 +1,44 @@
+import { db } from '../firebase';
+import {
+  collection,
+  query,
+  orderBy,
+  getDocs,
+  onSnapshot,
+  doc,
+  updateDoc,
+  increment,
+  limit as fsLimit,
+} from 'firebase/firestore';
+
+// Team: { id: string, name: string, pingas: number }
+
+export async function getLeaderboard() {
+  const q = query(collection(db, 'teams'), orderBy('pingas', 'desc'), orderBy('name'));
+  const snap = await getDocs(q);
+  return snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+}
+
+export function observeLeaderboard(callback) {
+  const q = query(collection(db, 'teams'), orderBy('pingas', 'desc'), orderBy('name'));
+  return onSnapshot(q, (snap) => {
+    const teams = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    callback(teams);
+  });
+}
+
+export async function addPinga(teamId, delta, actorUid) {
+  // Enforce service-level guardrails; rules will enforce too.
+  const n = Number(delta);
+  if (!Number.isInteger(n) || n < 1 || n > 5) {
+    throw new Error('Delta must be an integer between 1 and 5');
+  }
+  const ref = doc(db, 'teams', teamId);
+  await updateDoc(ref, { pingas: increment(n) });
+}
+
+export async function listEvents(limit = 20) {
+  const q = query(collection(db, 'events'), orderBy('ts', 'desc'), fsLimit(limit));
+  const snap = await getDocs(q);
+  return snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+}

--- a/src/services/teams.js
+++ b/src/services/teams.js
@@ -1,0 +1,37 @@
+import { db } from '../firebase';
+import {
+  collection,
+  query,
+  orderBy,
+  onSnapshot,
+  where,
+  getDocs,
+  addDoc,
+  doc,
+  deleteDoc,
+} from 'firebase/firestore';
+
+export function observeTeamsOrderedByName(callback) {
+  const q = query(collection(db, 'teams'), orderBy('name'));
+  return onSnapshot(q, (snap) => {
+    const teams = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    callback(teams);
+  });
+}
+
+export async function createTeamIfNotExists(name) {
+  const nameTrim = String(name || '').trim();
+  if (!nameTrim) throw new Error('Name is required');
+  const q = query(collection(db, 'teams'), where('name', '==', nameTrim));
+  const snap = await getDocs(q);
+  if (!snap.empty) {
+    const err = new Error('Team already exists');
+    err.code = 'already-exists';
+    throw err;
+  }
+  await addDoc(collection(db, 'teams'), { name: nameTrim, pingas: 0 });
+}
+
+export async function deleteTeam(teamId) {
+  await deleteDoc(doc(db, 'teams', teamId));
+}


### PR DESCRIPTION
## What

- Refactor to service layer: move all Firestore usage out of components/pages into `src/services/*`.
- New services:
  - `services/leaderboard`: `getLeaderboard()`, `observeLeaderboard()`, `addPinga(teamId, delta, actorUid)`, `listEvents(limit)`.
  - `services/teams`: `observeTeamsOrderedByName()`, `createTeamIfNotExists(name)`, `deleteTeam(teamId)`.
- Replace UI imports of `firebase/firestore` with service calls; preserve real-time updates via `observe*` helpers.
- Add unit tests for services under `src/services/__tests__/`.

## Why

- Enforce guardrail: no Firestore imports in UI layers.
- Improve separation of concerns and testability.

## How

- Pages/components now call services; services encapsulate Firestore queries/mutations.
- `addPinga` validates 1..5 delta client-side (rules also enforce).
- Tests mock Firestore modular API and `src/firebase` to verify behavior without network/emulator.

## Checks

- [x] Lint
- [x] Typecheck
- [x] Tests passing
- [x] Docs updated (README/CHANGELOG if needed)

