### PR TITLE
fix: handle VITE env vars on server

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -6,14 +6,14 @@ const env = (key, fallback) => {
   // Prefer Vite envs, fallback to CRA envs for transition compatibility
   const viteKey = `VITE_${key}`;
   const craKey = `REACT_APP_${key}`;
-  const viteVal =
-    (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env[viteKey]) ||
-    undefined;
   const proc =
     typeof globalThis !== 'undefined' && typeof globalThis.process !== 'undefined'
       ? globalThis.process
       : undefined;
-  const craVal = (proc && proc.env && proc.env[craKey]) || undefined;
+  const viteVal =
+    (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env[viteKey]) ||
+    (proc && proc.env && proc.env[viteKey]);
+  const craVal = proc && proc.env && proc.env[craKey];
   return viteVal ?? craVal ?? fallback;
 };
 


### PR DESCRIPTION
## Summary
- read `VITE_*` env vars from Node's `process.env`
- drop redundant `|| undefined` checks in env helper

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run typecheck`
- `npm test -- --watch=false` *(fails: jest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf68d6d148322be545c6b1f4d2a0f