### PR TITLE
fix: honor VITE env vars outside browser

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -6,15 +6,15 @@ const env = (key, fallback) => {
   // Prefer Vite envs, fallback to CRA envs for transition compatibility
   const viteKey = `VITE_${key}`;
   const craKey = `REACT_APP_${key}`;
+  const viteMeta =
+    typeof import.meta !== 'undefined' && import.meta.env && import.meta.env[viteKey];
   const proc =
     typeof globalThis !== 'undefined' && typeof globalThis.process !== 'undefined'
       ? globalThis.process
       : undefined;
-  const viteVal =
-    (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env[viteKey]) ||
-    (proc && proc.env && proc.env[viteKey]);
+  const viteProc = proc && proc.env && proc.env[viteKey];
   const craVal = proc && proc.env && proc.env[craKey];
-  return viteVal ?? craVal ?? fallback;
+  return viteMeta ?? viteProc ?? craVal ?? fallback;
 };
 
 const firebaseConfig = {


### PR DESCRIPTION
## Summary
- simplify env helper to avoid redundant fallbacks
- read VITE_* variables from process.env when available

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test -- --watch=false`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc1635a310832298ad9a2eace39682