### PR TITLE
feat: enforce branding and sponsor rules

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -19,6 +19,8 @@ VITE_FIREBASE_APP_ID=
 - Collections:
   - `teams`: { id, name, pingas }
   - `events` (audit): { ts, actorUid, type, delta, teamId }
+  - `branding/current`: { mainLogoDataUrl?, iconDataUrl? } (data URLs, max 180 KB each)
+  - `sponsors/{id}`: { name (≤80 chars), link (empty or https URL), imageDataUrl (≤180 KB data URL), active (bool), order (0-999) }
 
 ## Environments
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -15,14 +15,15 @@ yarn test:ci                     # CI mode with coverage
 yarn test:rules                  # Firestore security rules (emulator)
 yarn e2e                         # end-to-end (Playwright)
 
-Ensure Firestore emulator is running for rules tests:
-
+# `yarn test:rules` ensures Java is available (JAVA_HOME or Homebrew openjdk)
+# before launching `firebase emulators:exec`.
 ```
 
+When iterating on security rules interactively, run the emulator in a separate
+terminal instead:
+
+```
 firebase emulators:start --only firestore
-
-```
-
 ```
 
 ## Service Unit Tests
@@ -49,11 +50,16 @@ git grep "from 'firebase/firestore'" src/components src/pages
   - Public READ for `teams` (leaderboard) and `events`.
   - Admin WRITE to `teams`, `events`, and `app_config`.
   - Admin increments to `teams.pingas` with delta in [1..5].
+  - Public READ for `branding/current` and `sponsors`; admin writes must keep
+    image data URLs ≤ 180 KB.
 
 - Denied
   - Non-admin writes anywhere.
   - Increments > 5 or any decrement to `teams.pingas`.
   - Totals going negative.
   - Public READ of `app_config`.
+  - Invalid branding payloads (non-image data URLs or oversized assets).
+  - Invalid sponsor payloads (name > 80 chars, non-HTTPS links, bad image data,
+    non-bool `active`, or `order` outside 0–999).
 
 Rules tests live under `rules-tests/` and run via `yarn test:rules`.

--- a/firestore.rules
+++ b/firestore.rules
@@ -10,6 +10,18 @@ service cloud.firestore {
       return isSignedIn() && request.auth.token.admin == true;
     }
 
+    function isDataUrl(s) {
+      return s is string && s.matches('^data:image/.*');
+    }
+
+    function maxImgLen() {
+      return 180000;
+    }
+
+    function isValidImageDataUrl(dataUrl) {
+      return isDataUrl(dataUrl) && dataUrl.size() <= maxImgLen();
+    }
+
     // Leaderboard (teams) — public READ, admin WRITE with invariants
     match /teams/{teamId} {
       allow read: if true;
@@ -46,6 +58,32 @@ service cloud.firestore {
     match /app_config/{docId} {
       allow write: if isAdmin();
       allow read: if false;
+    }
+
+    // Branding — public READ, admin WRITE with validated data URLs
+    match /branding/current {
+      allow read: if true;
+      allow write: if isAdmin() &&
+        (!('mainLogoDataUrl' in request.resource.data) ||
+          isValidImageDataUrl(request.resource.data.mainLogoDataUrl)) &&
+        (!('iconDataUrl' in request.resource.data) ||
+          isValidImageDataUrl(request.resource.data.iconDataUrl));
+    }
+
+    function isValidSponsorData(data) {
+      return (data.name is string) && (data.name.size() <= 80) &&
+        ('link' in data) && (data.link is string) &&
+          (data.link.size() == 0 || data.link.matches('^https?://.+')) &&
+        ('imageDataUrl' in data) && isValidImageDataUrl(data.imageDataUrl) &&
+        ('active' in data) && (data.active is bool) &&
+        ('order' in data) && (data.order is int) &&
+        data.order >= 0 && data.order <= 999;
+    }
+
+    // Sponsors — public READ, admin WRITE with validated fields
+    match /sponsors/{sponsorId} {
+      allow read: if true;
+      allow write: if isAdmin() && isValidSponsorData(request.resource.data);
     }
 
     // Everything else denied

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "preview": "vite preview",
     "test": "vitest",
     "test:ci": "vitest --run --coverage",
-    "test:rules": "yarn --cwd rules-tests install --immutable && firebase emulators:exec --only firestore \"yarn --cwd rules-tests test\"",
+    "test:rules": "./scripts/test-rules.sh",
     "lint": "eslint --cache --max-warnings=0 \"src/**/*.{js,jsx,ts,tsx}\"",
     "lint:fix": "eslint --cache --fix \"src/**/*.{js,jsx,ts,tsx}\"",
     "format": "prettier --write .",

--- a/scripts/test-rules.sh
+++ b/scripts/test-rules.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Ensure we have a Java runtime available for the Firestore emulator
+if ! command -v java >/dev/null 2>&1; then
+  if command -v brew >/dev/null 2>&1 && brew --prefix openjdk >/dev/null 2>&1; then
+    export PATH="$(brew --prefix openjdk)/bin:$PATH"
+  elif [ -n "${JAVA_HOME:-}" ] && [ -x "$JAVA_HOME/bin/java" ]; then
+    export PATH="$JAVA_HOME/bin:$PATH"
+  fi
+fi
+
+if ! command -v java >/dev/null 2>&1; then
+  echo "Java runtime not found. Install OpenJDK (e.g. 'brew install openjdk') or set JAVA_HOME." >&2
+  exit 1
+fi
+
+yarn --cwd rules-tests install --immutable
+firebase emulators:exec --only firestore "yarn --cwd rules-tests test"


### PR DESCRIPTION
## What

- add branding/sponsor Firestore rules with validation helpers
- cover the new paths in the rules test suite
- make `yarn test:rules` Java-aware and document the additional invariants

## Why

- protect branding and sponsor content with public reads but strict admin writes
- ensure the new paths are covered by automated rules tests
- prevent future Java/path issues when running the emulator locally and surface new invariants in docs

## How

- add shared data URL helpers and sponsor validation logic in `firestore.rules`
- extend `rules-tests/firestore.rules.test.js` for branding/sponsor allow + deny cases
- route `yarn test:rules` through `scripts/test-rules.sh` and refresh configuration/testing docs

## Checks

- [ ] Lint
- [ ] Typecheck
- [x] Tests passing (`yarn test:rules`)
- [x] Docs updated (README/CHANGELOG if needed)
