### PR TITLE
feat: add branding and sponsor services

### DIFF
--- a/src/services/__tests__/branding.service.test.ts
+++ b/src/services/__tests__/branding.service.test.ts
@@ -1,0 +1,71 @@
+vi.mock('../../firebase', () => ({ db: {} }));
+
+const mockDoc = vi.fn(() => ({}));
+const mockGetDoc = vi.fn();
+const mockSetDoc = vi.fn();
+const mockServerTimestamp = vi.fn(() => 'server-ts');
+
+vi.mock('firebase/firestore', () => ({
+  doc: (...args: unknown[]) => mockDoc(...args),
+  getDoc: (...args: unknown[]) => mockGetDoc(...args),
+  setDoc: (...args: unknown[]) => mockSetDoc(...args),
+  serverTimestamp: () => mockServerTimestamp(),
+}));
+
+const compressImage = vi.fn();
+vi.mock('../../utils/image', () => ({
+  compressImage: (...args: unknown[]) => compressImage(...args),
+}));
+
+describe('branding.service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('getBranding returns empty object when doc missing', async () => {
+    mockGetDoc.mockResolvedValue({ exists: () => false });
+    const { getBranding } = await import('../branding.service');
+    const data = await getBranding();
+    expect(data).toEqual({});
+    expect(mockDoc).toHaveBeenCalledWith({}, 'branding', 'current');
+  });
+
+  test('getBranding returns stored data', async () => {
+    mockGetDoc.mockResolvedValue({
+      exists: () => true,
+      data: () => ({ mainLogoDataUrl: 'logo', iconDataUrl: 'icon', extra: 'x' }),
+    });
+    const { getBranding } = await import('../branding.service');
+    const data = await getBranding();
+    expect(data).toEqual({ mainLogoDataUrl: 'logo', iconDataUrl: 'icon' });
+  });
+
+  test('updateBranding compresses provided files and merges doc', async () => {
+    compressImage.mockResolvedValueOnce('compressed-main');
+    compressImage.mockResolvedValueOnce('compressed-icon');
+    const { updateBranding } = await import('../branding.service');
+    const mainFile = { name: 'main.png' } as unknown as File;
+    const iconFile = { name: 'icon.png' } as unknown as File;
+
+    await updateBranding({ mainLogoFile: mainFile, iconFile });
+
+    expect(compressImage).toHaveBeenNthCalledWith(1, mainFile);
+    expect(compressImage).toHaveBeenNthCalledWith(2, iconFile);
+    expect(mockSetDoc).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        mainLogoDataUrl: 'compressed-main',
+        iconDataUrl: 'compressed-icon',
+        updatedAt: 'server-ts',
+      }),
+      { merge: true }
+    );
+  });
+
+  test('updateBranding updates only timestamp when no files', async () => {
+    const { updateBranding } = await import('../branding.service');
+    await updateBranding({});
+    expect(compressImage).not.toHaveBeenCalled();
+    expect(mockSetDoc).toHaveBeenCalledWith({}, { updatedAt: 'server-ts' }, { merge: true });
+  });
+});

--- a/src/services/__tests__/sponsors.service.test.ts
+++ b/src/services/__tests__/sponsors.service.test.ts
@@ -1,0 +1,165 @@
+vi.mock('../../firebase', () => ({ db: {} }));
+
+const mockCollection = vi.fn(() => ({}));
+const mockQuery = vi.fn(() => ({}));
+const mockOrderBy = vi.fn((field: string, dir: string) => ({ field, dir }));
+const mockWhere = vi.fn(() => ({}));
+const mockGetDocs = vi.fn();
+const mockAddDoc = vi.fn();
+const mockDoc = vi.fn(() => ({}));
+const mockUpdateDoc = vi.fn();
+const mockDeleteDoc = vi.fn();
+const mockLimit = vi.fn(() => ({}));
+const batchUpdate = vi.fn();
+const batchCommit = vi.fn();
+const mockWriteBatch = vi.fn(() => ({ update: batchUpdate, commit: batchCommit }));
+const mockServerTimestamp = vi.fn(() => 'server-ts');
+
+vi.mock('firebase/firestore', () => ({
+  collection: (...args: unknown[]) => mockCollection(...args),
+  query: (...args: unknown[]) => mockQuery(...args),
+  orderBy: (...args: unknown[]) => mockOrderBy(...args),
+  where: (...args: unknown[]) => mockWhere(...args),
+  getDocs: (...args: unknown[]) => mockGetDocs(...args),
+  addDoc: (...args: unknown[]) => mockAddDoc(...args),
+  doc: (...args: unknown[]) => mockDoc(...args),
+  updateDoc: (...args: unknown[]) => mockUpdateDoc(...args),
+  deleteDoc: (...args: unknown[]) => mockDeleteDoc(...args),
+  limit: (...args: unknown[]) => mockLimit(...args),
+  writeBatch: (...args: unknown[]) => mockWriteBatch(...args),
+  serverTimestamp: () => mockServerTimestamp(),
+}));
+
+const compressImage = vi.fn();
+vi.mock('../../utils/image', () => ({
+  compressImage: (...args: unknown[]) => compressImage(...args),
+}));
+
+describe('sponsors.service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    batchUpdate.mockReset();
+    batchCommit.mockReset();
+  });
+
+  test('listSponsors returns mapped docs ordered by order asc', async () => {
+    mockGetDocs.mockResolvedValue({
+      docs: [
+        { id: 'a', data: () => ({ order: 0, name: 'A', active: true }) },
+        { id: 'b', data: () => ({ order: 1, name: 'B', active: false }) },
+      ],
+    });
+    const { listSponsors } = await import('../sponsors.service');
+    const sponsors = await listSponsors();
+    expect(mockQuery).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({ field: 'order', dir: 'asc' })
+    );
+    expect(mockOrderBy).toHaveBeenCalledWith('order', 'asc');
+    expect(sponsors).toEqual([
+      { id: 'a', order: 0, name: 'A', active: true },
+      { id: 'b', order: 1, name: 'B', active: false },
+    ]);
+  });
+
+  test('listSponsors with activeOnly filters', async () => {
+    mockGetDocs.mockResolvedValue({ docs: [] });
+    const { listSponsors } = await import('../sponsors.service');
+    await listSponsors({ activeOnly: true });
+    expect(mockQuery).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({ field: 'order', dir: 'asc' }),
+      expect.anything()
+    );
+    expect(mockWhere).toHaveBeenCalledWith('active', '==', true);
+  });
+
+  test('createSponsor compresses image, assigns order and timestamps', async () => {
+    compressImage.mockResolvedValue('compressed-image');
+    mockGetDocs.mockResolvedValueOnce({ empty: true, docs: [] });
+    mockAddDoc.mockResolvedValue({ id: 'new-id' });
+
+    const { createSponsor } = await import('../sponsors.service');
+    const file = { name: 'img.png' } as unknown as File;
+
+    const id = await createSponsor({ name: 'Sponsor', imageFile: file });
+
+    expect(id).toBe('new-id');
+    expect(compressImage).toHaveBeenCalledWith(file);
+    expect(mockAddDoc).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        name: 'Sponsor',
+        link: '',
+        imageDataUrl: 'compressed-image',
+        active: true,
+        order: 0,
+        createdAt: 'server-ts',
+        updatedAt: 'server-ts',
+      })
+    );
+  });
+
+  test('createSponsor throws when max order reached', async () => {
+    mockGetDocs.mockResolvedValueOnce({
+      empty: false,
+      docs: [{ data: () => ({ order: 999 }) }],
+    });
+    const { createSponsor } = await import('../sponsors.service');
+    await expect(
+      createSponsor({ name: 'Overflow', imageFile: { name: 'x.png' } as unknown as File })
+    ).rejects.toThrow('Maximum sponsor order reached');
+  });
+
+  test('updateSponsor merges provided fields and compresses new image', async () => {
+    compressImage.mockResolvedValue('new-img');
+    const { updateSponsor } = await import('../sponsors.service');
+    const file = { name: 'img.png' } as unknown as File;
+
+    await updateSponsor('id-1', {
+      name: 'Updated',
+      link: 'https://link',
+      imageFile: file,
+      active: false,
+    });
+
+    expect(compressImage).toHaveBeenCalledWith(file);
+    expect(mockUpdateDoc).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        name: 'Updated',
+        link: 'https://link',
+        imageDataUrl: 'new-img',
+        active: false,
+        updatedAt: 'server-ts',
+      })
+    );
+  });
+
+  test('deleteSponsor removes document', async () => {
+    const { deleteSponsor } = await import('../sponsors.service');
+    await deleteSponsor('id-2');
+    expect(mockDeleteDoc).toHaveBeenCalledWith({});
+  });
+
+  test('reorderSponsors updates batch with sequential order', async () => {
+    const { reorderSponsors } = await import('../sponsors.service');
+    batchUpdate.mockImplementation(() => {});
+    batchCommit.mockResolvedValue(undefined);
+
+    await reorderSponsors(['a', 'b', 'c']);
+
+    expect(mockWriteBatch).toHaveBeenCalledWith({});
+    expect(batchUpdate).toHaveBeenNthCalledWith(1, {}, { order: 0 });
+    expect(batchUpdate).toHaveBeenNthCalledWith(2, {}, { order: 1 });
+    expect(batchUpdate).toHaveBeenNthCalledWith(3, {}, { order: 2 });
+    expect(batchCommit).toHaveBeenCalled();
+  });
+
+  test('reorderSponsors throws when more than 1000 sponsors', async () => {
+    const { reorderSponsors } = await import('../sponsors.service');
+    const ids = Array.from({ length: 1001 }, (_, i) => `id-${i}`);
+    await expect(reorderSponsors(ids)).rejects.toThrow('Too many sponsors to reorder');
+    expect(batchCommit).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/branding.service.ts
+++ b/src/services/branding.service.ts
@@ -1,0 +1,48 @@
+import { doc, getDoc, serverTimestamp, setDoc } from 'firebase/firestore';
+import { compressImage } from '../utils/image';
+import { db } from '../firebase';
+
+const BRANDING_COLLECTION = 'branding';
+const BRANDING_DOC_ID = 'current';
+
+export interface BrandingData {
+  mainLogoDataUrl?: string;
+  iconDataUrl?: string;
+}
+
+export async function getBranding(): Promise<BrandingData> {
+  const ref = doc(db, BRANDING_COLLECTION, BRANDING_DOC_ID);
+  const snap = await getDoc(ref);
+  if (!snap.exists()) {
+    return {};
+  }
+  const data = snap.data() as BrandingData | undefined;
+  return {
+    mainLogoDataUrl: data?.mainLogoDataUrl,
+    iconDataUrl: data?.iconDataUrl,
+  };
+}
+
+interface UpdateBrandingParams {
+  mainLogoFile?: File | null;
+  iconFile?: File | null;
+}
+
+export async function updateBranding({
+  mainLogoFile,
+  iconFile,
+}: UpdateBrandingParams): Promise<void> {
+  const ref = doc(db, BRANDING_COLLECTION, BRANDING_DOC_ID);
+  const updates: Record<string, unknown> = {
+    updatedAt: serverTimestamp(),
+  };
+
+  if (mainLogoFile) {
+    updates.mainLogoDataUrl = await compressImage(mainLogoFile);
+  }
+  if (iconFile) {
+    updates.iconDataUrl = await compressImage(iconFile);
+  }
+
+  await setDoc(ref, updates, { merge: true });
+}

--- a/src/services/sponsors.service.ts
+++ b/src/services/sponsors.service.ts
@@ -1,0 +1,130 @@
+import {
+  addDoc,
+  collection,
+  deleteDoc,
+  doc,
+  getDocs,
+  limit,
+  orderBy,
+  query,
+  serverTimestamp,
+  updateDoc,
+  where,
+  writeBatch,
+} from 'firebase/firestore';
+import { compressImage } from '../utils/image';
+import { db } from '../firebase';
+
+const SPONSORS_COLLECTION = 'sponsors';
+const MAX_ORDER_VALUE = 999;
+
+export interface Sponsor {
+  id: string;
+  name: string;
+  link?: string;
+  imageDataUrl: string;
+  active: boolean;
+  order: number;
+}
+
+interface ListSponsorsOptions {
+  activeOnly?: boolean;
+}
+
+export async function listSponsors(options: ListSponsorsOptions = {}): Promise<Sponsor[]> {
+  const { activeOnly = false } = options;
+  const sponsorsRef = collection(db, SPONSORS_COLLECTION);
+  const constraints = [orderBy('order', 'asc')];
+  if (activeOnly) {
+    constraints.push(where('active', '==', true));
+  }
+  const snap = await getDocs(query(sponsorsRef, ...constraints));
+  return snap.docs.map((d) => ({ id: d.id, ...(d.data() as Omit<Sponsor, 'id'>) }));
+}
+
+interface CreateSponsorParams {
+  name: string;
+  link?: string;
+  imageFile: File;
+}
+
+async function nextOrderValue(): Promise<number> {
+  const sponsorsRef = collection(db, SPONSORS_COLLECTION);
+  const snap = await getDocs(query(sponsorsRef, orderBy('order', 'desc'), limit(1)));
+  if (snap.empty) {
+    return 0;
+  }
+  const topDoc = snap.docs[0];
+  const currentOrder = (topDoc.data()?.order as number | undefined) ?? 0;
+  if (currentOrder >= MAX_ORDER_VALUE) {
+    throw new Error('Maximum sponsor order reached');
+  }
+  return currentOrder + 1;
+}
+
+export async function createSponsor({
+  name,
+  link,
+  imageFile,
+}: CreateSponsorParams): Promise<string> {
+  const imageDataUrl = await compressImage(imageFile);
+  const orderValue = await nextOrderValue();
+  const timestamp = serverTimestamp();
+  const docRef = await addDoc(collection(db, SPONSORS_COLLECTION), {
+    name,
+    link: link ?? '',
+    imageDataUrl,
+    active: true,
+    order: orderValue,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  });
+  return docRef.id;
+}
+
+interface UpdateSponsorParams {
+  name?: string;
+  link?: string | null;
+  imageFile?: File | null;
+  active?: boolean;
+}
+
+export async function updateSponsor(
+  id: string,
+  { name, link, imageFile, active }: UpdateSponsorParams
+): Promise<void> {
+  const updates: Record<string, unknown> = {
+    updatedAt: serverTimestamp(),
+  };
+
+  if (typeof name !== 'undefined') {
+    updates.name = name;
+  }
+  if (typeof link !== 'undefined') {
+    updates.link = link ?? '';
+  }
+  if (typeof active !== 'undefined') {
+    updates.active = active;
+  }
+  if (imageFile) {
+    updates.imageDataUrl = await compressImage(imageFile);
+  }
+
+  await updateDoc(doc(db, SPONSORS_COLLECTION, id), updates);
+}
+
+export async function deleteSponsor(id: string): Promise<void> {
+  await deleteDoc(doc(db, SPONSORS_COLLECTION, id));
+}
+
+export async function reorderSponsors(idsInOrder: string[]): Promise<void> {
+  if (idsInOrder.length > MAX_ORDER_VALUE + 1) {
+    throw new Error('Too many sponsors to reorder');
+  }
+
+  const batch = writeBatch(db);
+  idsInOrder.forEach((id, index) => {
+    batch.update(doc(db, SPONSORS_COLLECTION, id), { order: index });
+  });
+  await batch.commit();
+}

--- a/src/utils/__tests__/image.test.ts
+++ b/src/utils/__tests__/image.test.ts
@@ -1,0 +1,107 @@
+const originalFileReader = global.FileReader;
+const OriginalImage = global.Image as typeof Image | undefined;
+const originalCreateElement = document.createElement;
+
+let toDataURLMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  class StubFileReader {
+    public result: string | ArrayBuffer | null = null;
+    public onload: ((this: FileReader, ev: ProgressEvent<FileReader>) => unknown) | null = null;
+    public onerror: ((this: FileReader, ev: ProgressEvent<FileReader>) => unknown) | null = null;
+
+    readAsDataURL() {
+      this.result = 'data:image/png;base64,AAA';
+      if (this.onload) {
+        this.onload.call(this as unknown as FileReader, {} as ProgressEvent<FileReader>);
+      }
+    }
+  }
+
+  global.FileReader = StubFileReader as unknown as typeof FileReader;
+
+  class StubImage {
+    public width = 800;
+    public height = 600;
+    public onload: (() => void) | null = null;
+    public onerror: (() => void) | null = null;
+
+    set src(_value: string) {
+      queueMicrotask(() => {
+        this.onload?.();
+      });
+    }
+  }
+
+  // @ts-expect-error - overriding for test
+  global.Image = StubImage;
+
+  toDataURLMock = vi.fn();
+  vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+    if (tagName === 'canvas') {
+      return {
+        width: 0,
+        height: 0,
+        getContext: () => ({ drawImage: vi.fn() }),
+        toDataURL: toDataURLMock,
+      } as unknown as HTMLCanvasElement;
+    }
+    return originalCreateElement.call(document, tagName);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (originalFileReader) {
+    global.FileReader = originalFileReader;
+  } else {
+    // @ts-expect-error - removing test stub when FileReader was undefined
+    delete global.FileReader;
+  }
+
+  if (OriginalImage) {
+    // @ts-expect-error - restoring for test environment
+    global.Image = OriginalImage;
+  } else {
+    // @ts-expect-error - removing stub
+    delete global.Image;
+  }
+});
+
+describe('compressImage', () => {
+  test('returns data URL within limit on first attempt', async () => {
+    toDataURLMock.mockReturnValue('data:image/jpeg;base64,' + 'a'.repeat(1000));
+    const { compressImage } = await import('../image');
+    const result = await compressImage({} as File);
+    expect(result.startsWith('data:image/jpeg')).toBe(true);
+    expect(toDataURLMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('retries at lower quality when above size cap', async () => {
+    toDataURLMock
+      .mockReturnValueOnce('data:image/jpeg;base64,' + 'a'.repeat(200000))
+      .mockReturnValueOnce('data:image/jpeg;base64,' + 'a'.repeat(1000));
+    const { compressImage } = await import('../image');
+    const result = await compressImage({} as File, { quality: 0.8 });
+    expect(result.length).toBeLessThanOrEqual(180000);
+    expect(toDataURLMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('throws when image remains above size cap', async () => {
+    toDataURLMock.mockReturnValue('data:image/jpeg;base64,' + 'a'.repeat(200000));
+    const { compressImage } = await import('../image');
+    await expect(compressImage({} as File)).rejects.toThrow(
+      'Unable to compress image below 180k characters'
+    );
+    expect(toDataURLMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('throws when initial quality already at fallback and too large', async () => {
+    toDataURLMock.mockReturnValue('data:image/jpeg;base64,' + 'a'.repeat(200000));
+    const { compressImage } = await import('../image');
+    await expect(compressImage({} as File, { quality: 0.6 })).rejects.toThrow(
+      'Unable to compress image below 180k characters'
+    );
+    expect(toDataURLMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -1,0 +1,115 @@
+const MAX_DATA_URL_LENGTH = 180000;
+const JPEG_MIME = 'image/jpeg';
+
+export interface CompressImageOptions {
+  maxW?: number;
+  maxH?: number;
+  quality?: number;
+}
+
+const DEFAULT_OPTIONS: Required<CompressImageOptions> = {
+  maxW: 600,
+  maxH: 600,
+  quality: 0.7,
+};
+
+function readFileAsDataURL(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = typeof reader.result === 'string' ? reader.result : '';
+      if (!result) {
+        reject(new Error('Failed to read image file'));
+        return;
+      }
+      resolve(result);
+    };
+    reader.onerror = () => reject(new Error('Failed to read image file'));
+    reader.readAsDataURL(file);
+  });
+}
+
+function loadImageElement(dataUrl: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error('Failed to load image for compression'));
+    img.src = dataUrl;
+  });
+}
+
+function computeTargetSize(
+  img: HTMLImageElement,
+  maxWidth: number,
+  maxHeight: number
+): { width: number; height: number } {
+  const { width, height } = img;
+  if (!width || !height) {
+    throw new Error('Image has invalid dimensions');
+  }
+  const widthRatio = maxWidth / width;
+  const heightRatio = maxHeight / height;
+  const ratio = Math.min(1, widthRatio, heightRatio);
+  const targetWidth = Math.round(width * ratio);
+  const targetHeight = Math.round(height * ratio);
+  return {
+    width: targetWidth || width,
+    height: targetHeight || height,
+  };
+}
+
+function encodeCanvas(canvas: HTMLCanvasElement, quality: number): string {
+  const nextQuality = Math.max(Math.min(quality, 1), 0.1);
+  const dataUrl = canvas.toDataURL(JPEG_MIME, nextQuality);
+  if (!dataUrl.startsWith('data:image')) {
+    throw new Error('Failed to encode image');
+  }
+  return dataUrl;
+}
+
+async function drawToCanvas(
+  img: HTMLImageElement,
+  width: number,
+  height: number
+): Promise<HTMLCanvasElement> {
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    throw new Error('Canvas 2D context not available');
+  }
+  ctx.drawImage(img, 0, 0, width, height);
+  return canvas;
+}
+
+export async function compressImage(
+  file: File,
+  options: CompressImageOptions = {}
+): Promise<string> {
+  const { maxW, maxH, quality } = { ...DEFAULT_OPTIONS, ...options };
+  const originalDataUrl = await readFileAsDataURL(file);
+  const imageElement = await loadImageElement(originalDataUrl);
+  const { width, height } = computeTargetSize(imageElement, maxW, maxH);
+  const canvas = await drawToCanvas(imageElement, width, height);
+
+  const primaryQuality = quality;
+  const primaryOutput = encodeCanvas(canvas, primaryQuality);
+  if (primaryOutput.length <= MAX_DATA_URL_LENGTH) {
+    return primaryOutput;
+  }
+
+  const fallbackQuality = 0.6;
+  if (Math.abs(primaryQuality - fallbackQuality) < 0.0001) {
+    throw new Error('Unable to compress image below 180k characters');
+  }
+
+  const fallbackOutput = encodeCanvas(canvas, fallbackQuality);
+  if (fallbackOutput.length <= MAX_DATA_URL_LENGTH) {
+    return fallbackOutput;
+  }
+
+  throw new Error('Unable to compress image below 180k characters');
+}
+
+export { MAX_DATA_URL_LENGTH };


### PR DESCRIPTION
## What

- add reusable image compression helper for admin uploads
- introduce branding and sponsors services backed by Firestore
- cover service flows with Vitest (mocked Firestore + compression)

## Why

- support admin branding uploads with client-side size guardrails
- enable sponsor management purely via services (no direct Firestore in UI)
- ensure key behaviours are validated with fast unit tests

## How

- implement JPEG compression utility with fallback compression when exceeding 180k chars
- add branding service to fetch/update `branding/current` using compressed data URLs
- add sponsors service for list/create/update/delete/reorder flows using server timestamps and batches
- exercise compression usage, order bounds, and batch updates with Vitest mocks

## Checks

- [x] Lint (pre-commit hook)
- [ ] Typecheck
- [x] Tests passing (`yarn test`)
- [ ] Docs updated (README/CHANGELOG if needed)
