### PR TITLE
feat: extract branding tokens and ui primitives

### DIFF
--- a/src/components/BrandingForm.jsx
+++ b/src/components/BrandingForm.jsx
@@ -1,6 +1,9 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import styles from './BrandingForm.module.css';
+import { Button } from './ui/Button';
+import { Card } from './ui/Card';
+import { FileInput } from './ui/FileInput';
 
 function revokeObjectUrl(ref) {
   if (ref.current) {
@@ -145,21 +148,34 @@ export default function BrandingForm({ initialBranding, isLoading, onSave }) {
       <fieldset className={styles.fieldset} disabled={disableForm}>
         <legend className={styles.legend}>Branding assets</legend>
         <div className={styles.assetsGrid}>
-          <div className={styles.assetCard}>
-            <div className={styles.assetHeader}>
-              <div>
-                <label htmlFor="mainLogo" className={styles.assetTitle}>
-                  Main logo
-                </label>
-                <p className={styles.assetHint}>Displayed on scoreboards and landing page</p>
-              </div>
-              {mainPreview ? (
-                <button type="button" className={styles.clearButton} onClick={handleRemoveMainLogo}>
-                  Remove
-                </button>
-              ) : null}
-            </div>
-            <p className={styles.constraints}>JPEG/PNG up to 600×600px (auto-compressed)</p>
+          <Card variant="glass" padding="lg" className={styles.assetCard}>
+            <FileInput
+              id="mainLogo"
+              ref={mainInputRef}
+              accept="image/*"
+              onChange={handleMainLogoChange}
+              fileName={mainLogoFile?.name ?? null}
+              buttonLabel="Choose image"
+              label={<span className={styles.assetTitle}>Main logo</span>}
+              hint={
+                <>
+                  <p className={styles.assetHint}>Displayed on scoreboards and landing page</p>
+                  <p className={styles.constraints}>JPEG/PNG up to 600×600px (auto-compressed)</p>
+                </>
+              }
+              action={
+                mainPreview ? (
+                  <Button
+                    type="button"
+                    variant="dangerSubtle"
+                    size="sm"
+                    onClick={handleRemoveMainLogo}
+                  >
+                    Remove
+                  </Button>
+                ) : null
+              }
+            />
             <div className={styles.previewFrameWide}>
               {mainPreview ? (
                 <img src={mainPreview} alt="Main logo preview" className={styles.previewImage} />
@@ -169,37 +185,31 @@ export default function BrandingForm({ initialBranding, isLoading, onSave }) {
                 </div>
               )}
             </div>
-            <div className={styles.uploadRow}>
-              <input
-                id="mainLogo"
-                ref={mainInputRef}
-                type="file"
-                accept="image/*"
-                className={styles.fileInput}
-                onChange={handleMainLogoChange}
-              />
-              <label htmlFor="mainLogo" className={styles.uploadButton}>
-                Choose image
-              </label>
-              {mainLogoFile ? <span className={styles.fileName}>{mainLogoFile.name}</span> : null}
-            </div>
-          </div>
+          </Card>
 
-          <div className={styles.assetCard}>
-            <div className={styles.assetHeader}>
-              <div>
-                <label htmlFor="icon" className={styles.assetTitle}>
-                  Icon
-                </label>
-                <p className={styles.assetHint}>Used for favicons &amp; mobile shortcuts</p>
-              </div>
-              {iconPreview ? (
-                <button type="button" className={styles.clearButton} onClick={handleRemoveIcon}>
-                  Remove
-                </button>
-              ) : null}
-            </div>
-            <p className={styles.constraints}>Square images look best (auto-resized)</p>
+          <Card variant="glass" padding="lg" className={styles.assetCard}>
+            <FileInput
+              id="icon"
+              ref={iconInputRef}
+              accept="image/*"
+              onChange={handleIconChange}
+              fileName={iconFile?.name ?? null}
+              buttonLabel="Choose image"
+              label={<span className={styles.assetTitle}>Icon</span>}
+              hint={
+                <>
+                  <p className={styles.assetHint}>Used for favicons &amp; mobile shortcuts</p>
+                  <p className={styles.constraints}>Square images look best (auto-resized)</p>
+                </>
+              }
+              action={
+                iconPreview ? (
+                  <Button type="button" variant="dangerSubtle" size="sm" onClick={handleRemoveIcon}>
+                    Remove
+                  </Button>
+                ) : null
+              }
+            />
             <div className={styles.previewFrameSquare}>
               {iconPreview ? (
                 <img src={iconPreview} alt="Icon preview" className={styles.previewImageSmall} />
@@ -209,39 +219,29 @@ export default function BrandingForm({ initialBranding, isLoading, onSave }) {
                 </div>
               )}
             </div>
-            <div className={styles.uploadRow}>
-              <input
-                id="icon"
-                ref={iconInputRef}
-                type="file"
-                accept="image/*"
-                className={styles.fileInput}
-                onChange={handleIconChange}
-              />
-              <label htmlFor="icon" className={styles.uploadButton}>
-                Choose image
-              </label>
-              {iconFile ? <span className={styles.fileName}>{iconFile.name}</span> : null}
-            </div>
-          </div>
+          </Card>
         </div>
       </fieldset>
 
-      {errorMessage ? (
-        <p role="alert" className={styles.errorMessage}>
-          {errorMessage}
-        </p>
-      ) : null}
-      {statusMessage ? (
-        <p role="status" className={styles.statusMessage}>
-          {statusMessage}
-        </p>
+      {errorMessage || statusMessage ? (
+        <div className={styles.statusStack}>
+          {errorMessage ? (
+            <p role="alert" className={styles.errorMessage}>
+              {errorMessage}
+            </p>
+          ) : null}
+          {statusMessage ? (
+            <p role="status" className={styles.statusMessage}>
+              {statusMessage}
+            </p>
+          ) : null}
+        </div>
       ) : null}
 
       <div className={styles.actions}>
-        <button type="submit" className={styles.saveButton} disabled={disableForm}>
+        <Button type="submit" disabled={disableForm}>
           {saving ? 'Saving…' : 'Save branding'}
-        </button>
+        </Button>
       </div>
     </form>
   );

--- a/src/components/BrandingForm.module.css
+++ b/src/components/BrandingForm.module.css
@@ -1,13 +1,7 @@
-:root {
-  --brand-card-shadow: 0 14px 34px rgba(15, 23, 42, 0.08);
-  --brand-border-muted: rgba(148, 163, 184, 0.35);
-  --brand-surface: linear-gradient(135deg, rgba(236, 253, 245, 0.72), rgba(240, 249, 255, 0.65));
-}
-
 .form {
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: var(--space-lg);
 }
 
 .fieldset {
@@ -17,56 +11,50 @@
 }
 
 .legend {
-  font-size: 0.9rem;
+  font-size: var(--font-size-sm);
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  font-weight: 800;
-  color: var(--text-secondary, #6b7280);
-  margin-bottom: 0.75rem;
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-sm);
 }
 
 .assetsGrid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 1.1rem;
+  gap: var(--space-lg);
 }
 
 .assetCard {
-  background: var(--brand-surface);
-  border-radius: 16px;
-  padding: 1.1rem;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  box-shadow: var(--brand-card-shadow);
-  backdrop-filter: blur(6px);
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: var(--space-md);
 }
 
 .assetHeader {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 0.75rem;
+  gap: var(--space-sm);
 }
 
 .assetTitle {
   font-size: clamp(1rem, 2.4vw, 1.2rem);
-  font-weight: 800;
-  color: var(--text-primary, #0f172a);
+  font-weight: var(--font-weight-extrabold);
+  color: var(--color-text-primary);
   display: block;
 }
 
 .assetHint {
   margin: 0.15rem 0 0;
-  font-size: 0.85rem;
+  font-size: var(--font-size-sm);
   color: rgba(30, 41, 59, 0.75);
 }
 
 .constraints {
   margin: 0;
-  font-size: 0.78rem;
-  font-weight: 600;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
   letter-spacing: 0.04em;
   text-transform: uppercase;
   color: rgba(30, 64, 175, 0.75);
@@ -75,8 +63,8 @@
 .previewFrameWide,
 .previewFrameSquare {
   background: rgba(255, 255, 255, 0.75);
-  border-radius: 14px;
-  border: 2px dashed var(--brand-border-muted);
+  border-radius: var(--radius-lg);
+  border: 2px dashed var(--color-border-strong);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -97,8 +85,8 @@
 .previewPlaceholder {
   text-align: center;
   color: rgba(100, 116, 139, 0.8);
-  font-size: 0.9rem;
-  padding: 0 1.25rem;
+  font-size: var(--font-size-sm);
+  padding: 0 var(--space-lg);
 }
 
 .previewImage {
@@ -113,95 +101,28 @@
   object-fit: cover;
 }
 
-.uploadRow {
+.statusStack {
   display: flex;
-  align-items: center;
-  gap: 0.6rem;
-  flex-wrap: wrap;
-}
-
-.fileInput {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  border: 0;
-  clip: rect(0 0 0 0);
-  overflow: hidden;
-  white-space: nowrap;
-}
-
-.uploadButton {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.35rem;
-  border-radius: 999px;
-  padding: 0.55rem 1.15rem;
-  background: #111827;
-  color: #f8fafc;
-  font-weight: 600;
-  cursor: pointer;
-  border: none;
-  transition:
-    transform 0.18s ease,
-    box-shadow 0.18s ease,
-    background 0.18s ease;
-}
-
-.uploadButton:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 10px 18px rgba(15, 23, 42, 0.22);
-  background: #0f172a;
-}
-
-.fileName {
-  font-size: 0.82rem;
-  color: rgba(15, 23, 42, 0.75);
-  max-width: 220px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.clearButton {
-  background: rgba(248, 113, 113, 0.12);
-  border: 1px solid rgba(220, 38, 38, 0.4);
-  color: #b91c1c;
-  border-radius: 999px;
-  padding: 0.35rem 0.85rem;
-  font-size: 0.78rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition:
-    background 0.18s ease,
-    color 0.18s ease,
-    transform 0.18s ease;
-}
-
-.clearButton:hover {
-  background: #ef4444;
-  color: #fff;
-  transform: translateY(-1px);
+  flex-direction: column;
+  gap: var(--space-sm);
 }
 
 .errorMessage {
-  color: #b91c1c;
-  background: rgba(254, 226, 226, 0.7);
-  border: 1px solid rgba(248, 113, 113, 0.45);
-  border-radius: 12px;
-  padding: 0.85rem 1rem;
-  font-weight: 600;
+  color: var(--color-danger-strong);
+  background: var(--color-danger-soft);
+  border: 1px solid var(--color-danger-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-sm) var(--space-md);
+  font-weight: var(--font-weight-semibold);
 }
 
 .statusMessage {
-  color: #0f766e;
-  background: rgba(16, 185, 129, 0.15);
+  color: var(--color-info);
+  background: var(--color-info-soft);
   border: 1px solid rgba(45, 212, 191, 0.4);
-  border-radius: 12px;
-  padding: 0.85rem 1rem;
-  font-weight: 600;
+  border-radius: var(--radius-md);
+  padding: var(--space-sm) var(--space-md);
+  font-weight: var(--font-weight-semibold);
 }
 
 .actions {
@@ -209,37 +130,9 @@
   justify-content: flex-end;
 }
 
-.saveButton {
-  background: var(--accent-green, #22c55e);
-  color: #fff;
-  border: none;
-  padding: 0.85rem 1.6rem;
-  border-radius: 999px;
-  font-size: 1rem;
-  font-weight: 700;
-  cursor: pointer;
-  transition:
-    background 0.2s ease,
-    transform 0.2s ease,
-    box-shadow 0.2s ease;
-  box-shadow: 0 12px 25px rgba(16, 185, 129, 0.25);
-}
-
-.saveButton:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-  box-shadow: none;
-}
-
-.saveButton:not(:disabled):hover {
-  background: #16a34a;
-  transform: translateY(-1px);
-  box-shadow: 0 16px 30px rgba(16, 185, 129, 0.35);
-}
-
 @media (max-width: 720px) {
   .assetCard {
-    padding: 1rem;
+    gap: var(--space-sm);
   }
 
   .previewFrameWide {

--- a/src/components/ui/Button.module.css
+++ b/src/components/ui/Button.module.css
@@ -1,0 +1,102 @@
+.button {
+  appearance: none;
+  border: none;
+  outline: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2xs);
+  font-family: inherit;
+  font-weight: var(--font-weight-bold);
+  line-height: var(--line-height-tight);
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  transition:
+    background-color 0.18s ease,
+    box-shadow 0.18s ease,
+    color 0.18s ease,
+    transform 0.18s ease;
+}
+
+.button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+.sizeSm {
+  padding: var(--space-xs) var(--space-md);
+  font-size: var(--font-size-sm);
+}
+
+.sizeMd {
+  padding: calc(var(--space-sm) + 0.05rem) var(--space-xl);
+  font-size: var(--font-size-md);
+}
+
+.fullWidth {
+  width: 100%;
+}
+
+.primary {
+  background: var(--color-accent);
+  color: var(--color-text-inverse);
+  box-shadow: var(--shadow-soft);
+}
+
+.primary:not(:disabled):hover,
+.primary:not(:disabled):focus-visible {
+  background: var(--color-accent-strong);
+  box-shadow: var(--shadow-pop);
+  transform: translateY(-1px);
+}
+
+.accentSubtle {
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+  border: 1px solid var(--color-accent-border);
+}
+
+.accentSubtle:not(:disabled):hover,
+.accentSubtle:not(:disabled):focus-visible {
+  background: var(--color-accent-soft-strong);
+  transform: translateY(-1px);
+}
+
+.danger {
+  background: var(--color-danger);
+  color: var(--color-text-inverse);
+  border: 1px solid transparent;
+}
+
+.danger:not(:disabled):hover,
+.danger:not(:disabled):focus-visible {
+  background: var(--color-danger-strong);
+  transform: translateY(-1px);
+}
+
+.dangerSubtle {
+  background: var(--color-danger-soft);
+  color: var(--color-danger-strong);
+  border: 1px solid var(--color-danger-border);
+}
+
+.dangerSubtle:not(:disabled):hover,
+.dangerSubtle:not(:disabled):focus-visible {
+  background: var(--color-danger);
+  color: var(--color-text-inverse);
+  transform: translateY(-1px);
+}
+
+.ghost {
+  background: transparent;
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border-muted);
+}
+
+.ghost:not(:disabled):hover,
+.ghost:not(:disabled):focus-visible {
+  background: var(--color-surface-subtle);
+  transform: translateY(-1px);
+}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,42 @@
+import { forwardRef, type ButtonHTMLAttributes } from 'react';
+import styles from './Button.module.css';
+
+type ButtonVariant = 'primary' | 'accentSubtle' | 'danger' | 'dangerSubtle' | 'ghost';
+type ButtonSize = 'sm' | 'md';
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  fullWidth?: boolean;
+}
+
+const variantClassName: Record<ButtonVariant, string> = {
+  primary: styles.primary,
+  accentSubtle: styles.accentSubtle,
+  danger: styles.danger,
+  dangerSubtle: styles.dangerSubtle,
+  ghost: styles.ghost,
+};
+
+const sizeClassName: Record<ButtonSize, string> = {
+  sm: styles.sizeSm,
+  md: styles.sizeMd,
+};
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className = '', variant = 'primary', size = 'md', fullWidth = false, ...props }, ref) => {
+    const classes = [
+      styles.button,
+      variantClassName[variant],
+      sizeClassName[size],
+      fullWidth ? styles.fullWidth : '',
+      className,
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    return <button ref={ref} className={classes} {...props} />;
+  }
+);
+
+Button.displayName = 'Button';

--- a/src/components/ui/Card.module.css
+++ b/src/components/ui/Card.module.css
@@ -1,0 +1,58 @@
+.card {
+  background: var(--color-surface-0);
+  border: 1px solid var(--color-border-muted);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-border);
+  display: flex;
+  flex-direction: column;
+}
+
+.paddingNone {
+  padding: 0;
+}
+
+.paddingSm {
+  padding: var(--space-md);
+}
+
+.paddingMd {
+  padding: var(--space-lg);
+}
+
+.paddingLg {
+  padding: var(--space-xl);
+}
+
+.radiusMd {
+  border-radius: var(--radius-md);
+}
+
+.radiusLg {
+  border-radius: var(--radius-lg);
+}
+
+.radiusXl {
+  border-radius: var(--radius-xl);
+}
+
+.variantDefault {
+  background: var(--color-surface-0);
+}
+
+.variantMuted {
+  background: var(--color-surface-subtle);
+  box-shadow: var(--shadow-card);
+}
+
+.variantGlass {
+  background: var(--color-surface-glass);
+  border-color: var(--color-border-strong);
+  box-shadow: var(--shadow-muted);
+  backdrop-filter: blur(6px);
+}
+
+.variantAccent {
+  background: linear-gradient(140deg, rgba(15, 118, 110, 0.08), rgba(34, 197, 94, 0.15));
+  border-color: rgba(45, 212, 191, 0.28);
+  box-shadow: var(--shadow-elevated);
+}

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,0 +1,50 @@
+import { forwardRef, type HTMLAttributes } from 'react';
+import styles from './Card.module.css';
+
+type CardVariant = 'default' | 'muted' | 'glass' | 'accent';
+type CardPadding = 'none' | 'sm' | 'md' | 'lg';
+type CardRadius = 'md' | 'lg' | 'xl';
+
+export interface CardProps extends HTMLAttributes<HTMLDivElement> {
+  variant?: CardVariant;
+  padding?: CardPadding;
+  radius?: CardRadius;
+}
+
+const variantClassName: Record<CardVariant, string> = {
+  default: styles.variantDefault,
+  muted: styles.variantMuted,
+  glass: styles.variantGlass,
+  accent: styles.variantAccent,
+};
+
+const paddingClassName: Record<CardPadding, string> = {
+  none: styles.paddingNone,
+  sm: styles.paddingSm,
+  md: styles.paddingMd,
+  lg: styles.paddingLg,
+};
+
+const radiusClassName: Record<CardRadius, string> = {
+  md: styles.radiusMd,
+  lg: styles.radiusLg,
+  xl: styles.radiusXl,
+};
+
+export const Card = forwardRef<HTMLDivElement, CardProps>(
+  ({ className = '', variant = 'default', padding = 'md', radius = 'lg', ...props }, ref) => {
+    const classes = [
+      styles.card,
+      variantClassName[variant],
+      paddingClassName[padding],
+      radiusClassName[radius],
+      className,
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    return <div ref={ref} className={classes} {...props} />;
+  }
+);
+
+Card.displayName = 'Card';

--- a/src/components/ui/FileInput.module.css
+++ b/src/components/ui/FileInput.module.css
@@ -1,0 +1,88 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.fullWidth {
+  width: 100%;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-sm);
+}
+
+.label {
+  font-size: clamp(var(--font-size-sm), 2vw, var(--font-size-md));
+  font-weight: var(--font-weight-extrabold);
+  color: var(--color-text-primary);
+}
+
+.hint {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.hint > * {
+  margin: 0;
+}
+
+.hiddenInput {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  border: 0;
+  clip: rect(0 0 0 0);
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.triggerButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2xs);
+  padding: calc(var(--space-sm) - 0.1rem) var(--space-lg);
+  border-radius: var(--radius-pill);
+  background: #111827;
+  color: #f8fafc;
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  border: none;
+  transition:
+    transform 0.18s ease,
+    box-shadow 0.18s ease,
+    background-color 0.18s ease;
+}
+
+.triggerButton:hover,
+.triggerButton:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px rgba(15, 23, 42, 0.22);
+  background: #0f172a;
+}
+
+.fileName {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  max-width: 220px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.headerAction {
+  flex-shrink: 0;
+}

--- a/src/components/ui/FileInput.tsx
+++ b/src/components/ui/FileInput.tsx
@@ -1,0 +1,79 @@
+import { forwardRef, useId, type InputHTMLAttributes, type ReactNode } from 'react';
+import styles from './FileInput.module.css';
+
+export interface FileInputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type' | 'className'> {
+  label: ReactNode;
+  hint?: ReactNode;
+  action?: ReactNode;
+  buttonLabel?: ReactNode;
+  fileName?: string | null;
+  fullWidth?: boolean;
+  className?: string;
+  inputClassName?: string;
+}
+
+export const FileInput = forwardRef<HTMLInputElement, FileInputProps>(
+  (
+    {
+      id,
+      label,
+      hint,
+      action,
+      buttonLabel = 'Choose file',
+      fileName,
+      className = '',
+      inputClassName = '',
+      fullWidth = true,
+      'aria-describedby': describedBy,
+      ...props
+    },
+    ref
+  ) => {
+    const generatedId = useId();
+    const inputId = id ?? `${generatedId}-file`;
+    const hintId = hint ? `${inputId}-hint` : undefined;
+    const describedByValue = [describedBy, hintId].filter(Boolean).join(' ') || undefined;
+
+    const wrapperClasses = [styles.wrapper, fullWidth ? styles.fullWidth : '', className]
+      .filter(Boolean)
+      .join(' ');
+
+    const inputClasses = [styles.hiddenInput, inputClassName].filter(Boolean).join(' ');
+
+    return (
+      <div className={wrapperClasses}>
+        <div className={styles.header}>
+          <label htmlFor={inputId} className={styles.label}>
+            {label}
+          </label>
+          {action ? <div className={styles.headerAction}>{action}</div> : null}
+        </div>
+        {hint ? (
+          <div id={hintId} className={styles.hint}>
+            {hint}
+          </div>
+        ) : null}
+        <div className={styles.controls}>
+          <input
+            id={inputId}
+            ref={ref}
+            type="file"
+            className={inputClasses}
+            aria-describedby={describedByValue}
+            {...props}
+          />
+          <label htmlFor={inputId} className={styles.triggerButton}>
+            {buttonLabel}
+          </label>
+          {fileName ? (
+            <span className={styles.fileName} title={fileName}>
+              {fileName}
+            </span>
+          ) : null}
+        </div>
+      </div>
+    );
+  }
+);
+
+FileInput.displayName = 'FileInput';

--- a/src/components/ui/Input.module.css
+++ b/src/components/ui/Input.module.css
@@ -1,0 +1,50 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+}
+
+.fullWidth {
+  width: 100%;
+}
+
+.label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-secondary);
+}
+
+.input {
+  width: 100%;
+  padding: calc(var(--space-sm) - 0.05rem) var(--space-md);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-muted);
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-base);
+  transition:
+    border-color 0.18s ease,
+    box-shadow 0.18s ease;
+}
+
+.input:focus-visible {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.18);
+  outline: none;
+}
+
+.inputError {
+  border-color: var(--color-danger);
+}
+
+.hint {
+  margin: 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+
+.error {
+  margin: 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-danger-strong);
+  font-weight: var(--font-weight-semibold);
+}

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,0 +1,56 @@
+import { forwardRef, useId, type InputHTMLAttributes } from 'react';
+import styles from './Input.module.css';
+
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  label?: React.ReactNode;
+  hint?: React.ReactNode;
+  error?: React.ReactNode;
+  fullWidth?: boolean;
+}
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ id, label, hint, error, className = '', fullWidth = true, 'aria-describedby': describedBy, ...props }, ref) => {
+    const generatedId = useId();
+    const inputId = id ?? generatedId;
+    const hintId = hint ? `${inputId}-hint` : undefined;
+    const errorId = error ? `${inputId}-error` : undefined;
+
+    const describedByValue = [describedBy, hintId, errorId].filter(Boolean).join(' ') || undefined;
+
+    const wrapperClasses = [styles.wrapper, fullWidth ? styles.fullWidth : '', className]
+      .filter(Boolean)
+      .join(' ');
+
+    const inputClasses = [styles.input, error ? styles.inputError : ''].filter(Boolean).join(' ');
+
+    return (
+      <div className={wrapperClasses}>
+        {label ? (
+          <label className={styles.label} htmlFor={inputId}>
+            {label}
+          </label>
+        ) : null}
+        <input
+          id={inputId}
+          ref={ref}
+          className={inputClasses}
+          aria-invalid={Boolean(error)}
+          aria-describedby={describedByValue}
+          {...props}
+        />
+        {hint ? (
+          <p id={hintId} className={styles.hint}>
+            {hint}
+          </p>
+        ) : null}
+        {error ? (
+          <p id={errorId} className={styles.error}>
+            {error}
+          </p>
+        ) : null}
+      </div>
+    );
+  }
+);
+
+Input.displayName = 'Input';

--- a/src/components/ui/Section.module.css
+++ b/src/components/ui/Section.module.css
@@ -1,0 +1,66 @@
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.paddingSm {
+  padding: var(--space-md);
+}
+
+.paddingMd {
+  padding: var(--space-lg);
+}
+
+.paddingLg {
+  padding: var(--space-xl);
+}
+
+.paddingXl {
+  padding: calc(var(--space-xl) * 1.2);
+}
+
+.radiusMd {
+  border-radius: var(--radius-md);
+}
+
+.radiusLg {
+  border-radius: var(--radius-lg);
+}
+
+.radiusXl {
+  border-radius: var(--radius-xl);
+}
+
+.variantPlain {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+}
+
+.variantSurface {
+  background: var(--color-surface-0);
+  border: 1px solid var(--color-border-muted);
+}
+
+.variantMuted {
+  background: rgba(248, 250, 252, 0.78);
+  border: 1px solid var(--color-border-muted);
+}
+
+.variantAccent {
+  background: linear-gradient(140deg, rgba(15, 118, 110, 0.08), rgba(34, 197, 94, 0.15));
+  border: 1px solid rgba(45, 212, 191, 0.28);
+}
+
+.shadowNone {
+  box-shadow: none;
+}
+
+.shadowCard {
+  box-shadow: var(--shadow-card);
+}
+
+.shadowElevated {
+  box-shadow: var(--shadow-elevated);
+}

--- a/src/components/ui/Section.tsx
+++ b/src/components/ui/Section.tsx
@@ -1,0 +1,72 @@
+import { forwardRef, type HTMLAttributes } from 'react';
+import styles from './Section.module.css';
+
+type SectionVariant = 'plain' | 'surface' | 'muted' | 'accent';
+type SectionPadding = 'sm' | 'md' | 'lg' | 'xl';
+type SectionRadius = 'md' | 'lg' | 'xl';
+type SectionShadow = 'none' | 'card' | 'elevated';
+
+export interface SectionProps extends HTMLAttributes<HTMLElement> {
+  as?: 'div' | 'section';
+  variant?: SectionVariant;
+  padding?: SectionPadding;
+  radius?: SectionRadius;
+  shadow?: SectionShadow;
+}
+
+const variantClassName: Record<SectionVariant, string> = {
+  plain: styles.variantPlain,
+  surface: styles.variantSurface,
+  muted: styles.variantMuted,
+  accent: styles.variantAccent,
+};
+
+const paddingClassName: Record<SectionPadding, string> = {
+  sm: styles.paddingSm,
+  md: styles.paddingMd,
+  lg: styles.paddingLg,
+  xl: styles.paddingXl,
+};
+
+const radiusClassName: Record<SectionRadius, string> = {
+  md: styles.radiusMd,
+  lg: styles.radiusLg,
+  xl: styles.radiusXl,
+};
+
+const shadowClassName: Record<SectionShadow, string> = {
+  none: styles.shadowNone,
+  card: styles.shadowCard,
+  elevated: styles.shadowElevated,
+};
+
+export const Section = forwardRef<HTMLElement, SectionProps>(
+  (
+    {
+      as = 'section',
+      className = '',
+      variant = 'plain',
+      padding = 'md',
+      radius = 'lg',
+      shadow = 'none',
+      ...props
+    },
+    ref
+  ) => {
+    const Component = as;
+    const classes = [
+      styles.section,
+      variantClassName[variant],
+      paddingClassName[padding],
+      radiusClassName[radius],
+      shadowClassName[shadow],
+      className,
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    return <Component ref={ref as never} className={classes} {...props} />;
+  }
+);
+
+Section.displayName = 'Section';

--- a/src/components/ui/__tests__/primitives.test.tsx
+++ b/src/components/ui/__tests__/primitives.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Button } from '../Button';
+import { Card } from '../Card';
+import { FileInput } from '../FileInput';
+import { Input } from '../Input';
+import { Section } from '../Section';
+
+describe('UI primitives', () => {
+  it('renders a button and handles clicks', () => {
+    const handleClick = vi.fn();
+    render(
+      <Button onClick={handleClick} variant="primary">
+        Click me
+      </Button>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /click me/i }));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a card with children', () => {
+    render(
+      <Card>
+        <p data-testid="card-child">Child content</p>
+      </Card>
+    );
+
+    expect(screen.getByTestId('card-child')).toBeInTheDocument();
+  });
+
+  it('renders an input and notifies on change', () => {
+    const handleChange = vi.fn();
+    render(
+      <Input
+        placeholder="Email"
+        value=""
+        onChange={(event) => handleChange(event.target.value)}
+      />
+    );
+
+    const input = screen.getByPlaceholderText('Email');
+    fireEvent.change(input, { target: { value: 'test@example.com' } });
+    expect(handleChange).toHaveBeenCalledWith('test@example.com');
+  });
+
+  it('renders a file input and exposes change events', () => {
+    const handleChange = vi.fn();
+    const file = new File(['content'], 'logo.png', { type: 'image/png' });
+
+    render(
+      <FileInput
+        label="Upload"
+        onChange={(event) => handleChange(event.target.files?.[0]?.name)}
+        data-testid="file-input"
+      />
+    );
+
+    const input = screen.getByTestId('file-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+
+    expect(handleChange).toHaveBeenCalledWith('logo.png');
+  });
+
+  it('renders a section with custom element', () => {
+    const { container } = render(
+      <Section as="div" variant="surface">
+        Content
+      </Section>
+    );
+
+    expect(container.firstChild?.nodeName).toBe('DIV');
+  });
+});

--- a/src/globals.css
+++ b/src/globals.css
@@ -1,18 +1,10 @@
-:root {
-  /* Paleta de Cores */
-  --bg-page: #f3f4f6;
-  --bg-card: #ffffff;
-  --text-primary: #111827;
-  --text-secondary: #374151;
-  --accent-green: #10b981;
-  --accent-hover: rgba(16, 185, 129, 0.1);
-}
+@import './styles/tokens.css';
 
-/* Importa depois dos @tailwind ou no topo se não usares Tailwind */
 body {
-  background: var(--bg-page);
+  background: var(--color-page-bg);
   margin: 0;
-  font-family: sans-serif;
+  font-family: var(--font-family-sans);
+  color: var(--color-text-primary);
 }
 
 html,
@@ -20,18 +12,21 @@ body,
 #root {
   height: 100%;
 }
+
 html,
 body {
   margin: 0;
   padding: 0;
-  overflow-x: hidden; /* prevent page-wide horizontal scroll */
+  overflow-x: hidden;
   width: 100%;
 }
+
 *,
 *::before,
 ::after {
-  box-sizing: border-box; /* safer sizing */
+  box-sizing: border-box;
 }
+
 img,
 svg,
 video,

--- a/src/pages/Branding.jsx
+++ b/src/pages/Branding.jsx
@@ -5,8 +5,11 @@ import Header from '../components/Header';
 import { auth } from '../firebase';
 import BrandingForm from '../components/BrandingForm';
 import { getBranding, updateBranding } from '../services/branding.service';
-import styles from './Admin.module.css';
 import pageStyles from './Branding.module.css';
+import { Button } from '../components/ui/Button';
+import { Card } from '../components/ui/Card';
+import { Input } from '../components/ui/Input';
+import { Section } from '../components/ui/Section';
 
 function useAdminAuth() {
   const [user, setUser] = useState(null);
@@ -80,44 +83,46 @@ export default function Branding() {
     return (
       <>
         <Header />
-        <div className={styles.card}>
-          <h2 className={styles.title}>Admin Login</h2>
-          {loginError ? (
-            <p role="alert" className={styles.errorText}>
-              {loginError}
-            </p>
-          ) : null}
-          <form
-            onSubmit={(e) => {
-              e.preventDefault();
-              setLoginError(null);
-              login().catch((err) => {
-                setLoginError(err?.message || 'Failed to login');
-              });
-            }}
-            className={styles.loginForm}
-          >
-            <input
-              type="email"
-              placeholder="Email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              className={styles.input}
-              required
-            />
-            <input
-              type="password"
-              placeholder="Password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              className={styles.input}
-              required
-            />
-            <button type="submit" className={styles.loginBtn}>
-              Login
-            </button>
-          </form>
-        </div>
+        <main className={pageStyles.page}>
+          <Card className={pageStyles.loginCard} padding="lg" radius="lg">
+            <h2 className={pageStyles.loginHeader}>Admin Login</h2>
+            {loginError ? (
+              <p role="alert" className={pageStyles.alert}>
+                {loginError}
+              </p>
+            ) : null}
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                setLoginError(null);
+                login().catch((err) => {
+                  setLoginError(err?.message || 'Failed to login');
+                });
+              }}
+              className={pageStyles.loginForm}
+            >
+              <Input
+                type="email"
+                placeholder="Email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                className={pageStyles.loginInput}
+              />
+              <Input
+                type="password"
+                placeholder="Password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                className={pageStyles.loginInput}
+              />
+              <Button type="submit" className={pageStyles.loginButton}>
+                Login
+              </Button>
+            </form>
+          </Card>
+        </main>
       </>
     );
   }
@@ -125,8 +130,15 @@ export default function Branding() {
   return (
     <>
       <Header />
-      <main className={pageStyles.wrapper}>
-        <div className={pageStyles.heroShell}>
+      <main className={pageStyles.page}>
+        <Section
+          as="div"
+          variant="accent"
+          padding="lg"
+          radius="xl"
+          shadow="elevated"
+          className={pageStyles.heroShell}
+        >
           <div className={pageStyles.heroContent}>
             <span className={pageStyles.microTitle}>Admin · Branding</span>
             <h1 className={pageStyles.heroTitle}>Customize the Taça da Pinga visuals</h1>
@@ -136,18 +148,14 @@ export default function Branding() {
             </p>
           </div>
           <div className={pageStyles.heroActions}>
-            <button
-              type="button"
-              className={pageStyles.backButton}
-              onClick={() => navigate('/admin')}
-            >
+            <Button type="button" variant="accentSubtle" onClick={() => navigate('/admin')}>
               ← Voltar ao painel
-            </button>
-            <button onClick={logout} className={pageStyles.logoutButton}>
+            </Button>
+            <Button type="button" variant="danger" onClick={logout}>
               Logout
-            </button>
+            </Button>
           </div>
-        </div>
+        </Section>
 
         {loadError ? (
           <p role="alert" className={pageStyles.errorBanner}>
@@ -155,7 +163,14 @@ export default function Branding() {
           </p>
         ) : null}
 
-        <section className={pageStyles.formSection}>
+        <Section
+          as="section"
+          variant="muted"
+          padding="lg"
+          radius="xl"
+          shadow="card"
+          className={pageStyles.formSection}
+        >
           <BrandingForm
             initialBranding={initialData}
             isLoading={isLoading}
@@ -165,7 +180,7 @@ export default function Branding() {
               setInitialData(refreshed || {});
             }}
           />
-        </section>
+        </Section>
       </main>
     </>
   );

--- a/src/pages/Branding.module.css
+++ b/src/pages/Branding.module.css
@@ -1,4 +1,4 @@
-.wrapper {
+.page {
   padding: clamp(1.2rem, 3vh, 2rem) clamp(1rem, 4vw, 3rem) clamp(2rem, 5vh, 4rem);
   background: radial-gradient(circle at top, rgba(236, 253, 245, 0.65), rgba(241, 245, 249, 0.45));
   min-height: 100vh;
@@ -11,39 +11,34 @@
 .heroShell {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
-  padding: clamp(1.5rem, 4vw, 2.5rem);
-  border-radius: 24px;
-  background: linear-gradient(140deg, rgba(15, 118, 110, 0.08), rgba(34, 197, 94, 0.15));
-  border: 1px solid rgba(45, 212, 191, 0.28);
-  box-shadow: 0 32px 60px rgba(15, 118, 110, 0.12);
+  gap: var(--space-lg);
 }
 
 .heroContent {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: var(--space-sm);
 }
 
 .microTitle {
   text-transform: uppercase;
   font-size: 0.78rem;
   letter-spacing: 0.2em;
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
   color: rgba(15, 23, 42, 0.52);
 }
 
 .heroTitle {
   font-size: clamp(1.75rem, 4vw, 2.4rem);
   margin: 0;
-  font-weight: 800;
-  color: #0f172a;
+  font-weight: var(--font-weight-extrabold);
+  color: var(--color-text-primary);
 }
 
 .subtitle {
   margin: 0;
   font-size: clamp(0.95rem, 2vw, 1.05rem);
-  line-height: 1.65;
+  line-height: var(--line-height-relaxed);
   color: rgba(15, 23, 42, 0.74);
   max-width: 60ch;
 }
@@ -51,62 +46,67 @@
 .heroActions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.6rem;
-}
-
-.backButton {
-  font-weight: 700;
-  border-radius: 999px;
-  padding: 0.7rem 1.5rem;
-  border: 1px solid rgba(34, 197, 94, 0.5);
-  color: var(--accent-green, #22c55e);
-  background: rgba(34, 197, 94, 0.12);
-  cursor: pointer;
-  transition:
-    background 0.18s ease,
-    transform 0.18s ease;
-}
-
-.backButton:hover {
-  background: rgba(34, 197, 94, 0.2);
-  transform: translateY(-1px);
-}
-
-.logoutButton {
-  border-radius: 999px;
-  padding: 0.7rem 1.5rem;
-  border: 1px solid rgba(239, 68, 68, 0.55);
-  color: #ef4444;
-  background: rgba(254, 226, 226, 0.5);
-  cursor: pointer;
-  font-weight: 700;
-  transition:
-    background 0.18s ease,
-    color 0.18s ease,
-    transform 0.18s ease;
-}
-
-.logoutButton:hover {
-  background: #ef4444;
-  color: white;
-  transform: translateY(-1px);
+  gap: var(--space-sm);
 }
 
 .errorBanner {
-  background: rgba(254, 226, 226, 0.8);
+  background: var(--color-danger-soft);
   border: 1px solid rgba(248, 113, 113, 0.45);
-  border-radius: 18px;
-  padding: 0.9rem 1.1rem;
-  font-weight: 600;
-  color: #b91c1c;
+  border-radius: var(--radius-lg);
+  padding: var(--space-sm) var(--space-md);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-danger-strong);
 }
 
 .formSection {
-  background: rgba(248, 250, 252, 0.78);
-  border-radius: 24px;
-  padding: clamp(1rem, 1.5vw, 0.5rem);
-  border: 1px solid rgba(148, 163, 184, 0.28);
-  box-shadow: 0 36px 60px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.loginCard {
+  max-width: 760px;
+  margin: 1.25rem auto;
+  width: 100%;
+}
+
+.loginHeader {
+  margin: 0;
+  font-size: clamp(1.25rem, 2.2vw, 1.6rem);
+  font-weight: var(--font-weight-extrabold);
+  color: var(--color-text-primary);
+}
+
+.loginForm {
+  display: flex;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+  align-items: center;
+  margin-top: var(--space-md);
+}
+
+.loginInput {
+  flex: 1 1 220px;
+  min-width: 220px;
+}
+
+.loginButton {
+  flex-shrink: 0;
+}
+
+.alert {
+  color: var(--color-danger);
+  background: rgba(239, 68, 68, 0.1);
+  border-radius: var(--radius-md);
+  padding: var(--space-sm);
+  margin: 0;
+  font-weight: var(--font-weight-semibold);
+}
+
+.statusRow {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
 }
 
 @media (min-width: 900px) {

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,0 +1,71 @@
+:root {
+  /* Color palette */
+  --color-page-bg: #f3f4f6;
+  --color-surface-0: #ffffff;
+  --color-surface-subtle: #f8fafc;
+  --color-surface-glass: linear-gradient(135deg, rgba(236, 253, 245, 0.72), rgba(240, 249, 255, 0.65));
+  --color-text-primary: #0f172a;
+  --color-text-secondary: #374151;
+  --color-text-muted: rgba(15, 23, 42, 0.65);
+  --color-text-inverse: #f8fafc;
+
+  --color-accent: #22c55e;
+  --color-accent-strong: #16a34a;
+  --color-accent-soft: rgba(34, 197, 94, 0.12);
+  --color-accent-soft-strong: rgba(34, 197, 94, 0.2);
+  --color-accent-border: rgba(34, 197, 94, 0.5);
+
+  --color-danger: #ef4444;
+  --color-danger-strong: #b91c1c;
+  --color-danger-soft: rgba(254, 226, 226, 0.5);
+  --color-danger-border: rgba(239, 68, 68, 0.55);
+
+  --color-info: #0f766e;
+  --color-info-soft: rgba(16, 185, 129, 0.15);
+
+  --color-border-muted: rgba(148, 163, 184, 0.28);
+  --color-border-strong: rgba(148, 163, 184, 0.45);
+
+  /* Shadows */
+  --shadow-soft: 0 12px 25px rgba(16, 185, 129, 0.25);
+  --shadow-pop: 0 16px 30px rgba(16, 185, 129, 0.35);
+  --shadow-elevated: 0 32px 60px rgba(15, 118, 110, 0.12);
+  --shadow-card: 0 36px 60px rgba(15, 23, 42, 0.08);
+  --shadow-muted: 0 14px 34px rgba(15, 23, 42, 0.08);
+  --shadow-border: 0 2px 10px rgba(17, 24, 39, 0.08);
+
+  /* Radii */
+  --radius-xs: 6px;
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+  --radius-xl: 24px;
+  --radius-pill: 999px;
+
+  /* Spacing scale */
+  --space-3xs: 0.125rem;
+  --space-2xs: 0.25rem;
+  --space-xs: 0.5rem;
+  --space-sm: 0.75rem;
+  --space-md: 1rem;
+  --space-lg: 1.5rem;
+  --space-xl: 2rem;
+  --space-2xl: 3rem;
+
+  /* Typography */
+  --font-family-sans: 'Inter', 'Helvetica Neue', Arial, sans-serif;
+  --font-size-xs: 0.75rem;
+  --font-size-sm: 0.875rem;
+  --font-size-md: 1rem;
+  --font-size-lg: 1.125rem;
+  --font-size-xl: 1.5rem;
+  --font-size-2xl: 2rem;
+  --font-weight-regular: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+  --font-weight-extrabold: 800;
+  --line-height-tight: 1.25;
+  --line-height-base: 1.5;
+  --line-height-relaxed: 1.65;
+}


### PR DESCRIPTION
## Summary
- add reusable design tokens for color, spacing, radius, typography, and shadows
- introduce shared Button, Card, Input, FileInput, and Section primitives powered by the tokens
- refactor the Branding page and form to consume the primitives without changing behavior
- add RTL smoke tests covering the new UI primitives

## Testing
- yarn lint
- yarn typecheck
- yarn test --run
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68cdca7cdfb083309a929651dee28e0b