### PR TITLE
feat(ci): auto deploy develop to dedicated hosting

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,5 +1,12 @@
 {
   "projects": {
     "default": "taca-da-pinga"
+  },
+  "targets": {
+    "taca-da-pinga": {
+      "hosting": {
+        "develop": ["develop-taca-da-pinga"]
+      }
+    }
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [production, develop]
   pull_request:
     branches: [production, develop]
   workflow_dispatch:

--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -1,0 +1,129 @@
+name: Deploy Develop
+
+on:
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    env:
+      VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
+      VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
+      VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+      VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}
+      VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
+      VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Prepare Yarn 4
+        run: corepack prepare yarn@4.3.1 --activate
+
+      - name: Validate Firebase web config
+        run: |
+          missing=0
+          for key in \
+            VITE_FIREBASE_API_KEY \
+            VITE_FIREBASE_AUTH_DOMAIN \
+            VITE_FIREBASE_PROJECT_ID \
+            VITE_FIREBASE_STORAGE_BUCKET \
+            VITE_FIREBASE_MESSAGING_SENDER_ID \
+            VITE_FIREBASE_APP_ID
+          do
+            if [ -z "${!key:-}" ]; then
+              echo "::error::Missing secret: $key" >&2
+              missing=1
+            fi
+          done
+
+          if [ "$missing" -ne 0 ]; then
+            echo "Firebase web configuration secrets are required for the develop deploy" >&2
+            exit 1
+          fi
+
+      - name: Cache Yarn global cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.yarn/berry/cache
+          key: ${{ runner.os }}-yarn-berry-cache-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-berry-cache-
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Unit tests
+        run: yarn test:ci
+
+      - name: Rules tests (Firestore emulator)
+        run: yarn test:rules
+
+      - name: Typecheck
+        run: yarn typecheck || true
+
+      - name: Build
+        run: yarn build
+
+      - name: Configure Firebase credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+        run: |
+          if [ -z "${FIREBASE_SERVICE_ACCOUNT}" ]; then
+            echo "Missing FIREBASE_SERVICE_ACCOUNT secret" >&2
+            exit 1
+          fi
+
+          echo "${FIREBASE_SERVICE_ACCOUNT}" > "${HOME}/firebaseServiceAccount.json"
+          echo "GOOGLE_APPLICATION_CREDENTIALS=${HOME}/firebaseServiceAccount.json" >> "${GITHUB_ENV}"
+
+      - name: Deploy Firestore rules (if configured)
+        env:
+          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+        run: |
+          set -o errexit
+          set -o pipefail
+
+          PROJECT_ARG=""
+          if [ -n "${FIREBASE_PROJECT_ID:-}" ]; then
+            PROJECT_ARG="--project ${FIREBASE_PROJECT_ID}"
+          fi
+
+          if [ -f firestore.rules ]; then
+            ./node_modules/.bin/firebase deploy --only firestore:rules ${PROJECT_ARG}
+          else
+            echo "No Firestore rules to deploy, skipping"
+          fi
+
+      - name: Deploy hosting (develop)
+        env:
+          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+        run: |
+          set -o errexit
+          set -o pipefail
+
+          PROJECT_ARG=""
+          if [ -n "${FIREBASE_PROJECT_ID:-}" ]; then
+            PROJECT_ARG="--project ${FIREBASE_PROJECT_ID}"
+          fi
+
+          ./node_modules/.bin/firebase deploy --only hosting:develop ${PROJECT_ARG}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -156,17 +156,7 @@ jobs:
             exit 1
           fi
 
-          ./node_modules/.bin/firebase hosting:channel:deploy "${PREVIEW_CHANNEL}" --project "${PROJECT_ID}" --json > firebase-deploy.json 2> firebase-deploy.log
-          STATUS=$?
-
-          if [ "${STATUS}" -ne 0 ]; then
-            echo "firebase hosting:channel:deploy failed" >&2
-            cat firebase-deploy.log >&2 || true
-            if [ -f firebase-deploy.json ]; then
-              cat firebase-deploy.json >&2
-            fi
-            exit ${STATUS}
-          fi
+          ./node_modules/.bin/firebase hosting:channel:deploy "${PREVIEW_CHANNEL}" --project "${PROJECT_ID}" --json | tee firebase-deploy.json
 
           node <<'NODE'
           const fs = require('fs');

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -2,9 +2,7 @@ name: PR Preview
 
 on:
   pull_request:
-    branches:
-      - develop
-      - production
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -94,6 +92,47 @@ jobs:
 
           echo "${FIREBASE_SERVICE_ACCOUNT}" > "${HOME}/firebaseServiceAccount.json"
           echo "GOOGLE_APPLICATION_CREDENTIALS=${HOME}/firebaseServiceAccount.json" >> "${GITHUB_ENV}"
+
+      - name: Ensure static preview site exists
+        env:
+          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+          STATIC_SITE: ${{ env.PREVIEW_STATIC_SITE }}
+        run: |
+          set -o errexit
+          set -o pipefail
+
+          PROJECT_ID="${FIREBASE_PROJECT_ID:-$FIREBASE_DEFAULT_PROJECT}"
+
+          ./node_modules/.bin/firebase hosting:sites:list --project "${PROJECT_ID}" --json > firebase-sites.json
+
+          STATUS=$(node <<'NODE'
+          const fs = require('fs');
+          const payload = JSON.parse(fs.readFileSync('firebase-sites.json', 'utf8'));
+          const sites = [];
+          if (Array.isArray(payload?.result)) {
+            sites.push(...payload.result);
+          } else if (Array.isArray(payload?.result?.sites)) {
+            sites.push(...payload.result.sites);
+          } else if (Array.isArray(payload?.sites)) {
+            sites.push(...payload.sites);
+          }
+
+          const target = process.env.STATIC_SITE;
+          const found = sites.some((entry) => {
+            if (!entry) return false;
+            const name = typeof entry === 'string' ? entry : entry.name || entry.site || entry.id;
+            if (!name) return false;
+            return name === target || name.endsWith(`/${target}`);
+          });
+
+          process.stdout.write(found ? 'exists' : 'missing');
+          NODE
+          )
+
+          if [ "${STATUS}" = "missing" ]; then
+            echo "Creating hosting site ${STATIC_SITE} in project ${PROJECT_ID}" >&2
+            ./node_modules/.bin/firebase hosting:sites:create "${STATIC_SITE}" --project "${PROJECT_ID}" --non-interactive
+          fi
 
       - name: Deploy to Firebase preview channel
         id: deploy

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -103,6 +103,11 @@ jobs:
 
           PROJECT_ID="${FIREBASE_PROJECT_ID:-$FIREBASE_DEFAULT_PROJECT}"
 
+          if [ -z "${PROJECT_ID}" ]; then
+            echo "Missing Firebase project id" >&2
+            exit 1
+          fi
+
           ./node_modules/.bin/firebase hosting:sites:list --project "${PROJECT_ID}" --json > firebase-sites.json
 
           STATUS=$(node <<'NODE'
@@ -131,7 +136,10 @@ jobs:
 
           if [ "${STATUS}" = "missing" ]; then
             echo "Creating hosting site ${STATIC_SITE} in project ${PROJECT_ID}" >&2
-            ./node_modules/.bin/firebase hosting:sites:create "${STATIC_SITE}" --project "${PROJECT_ID}" --non-interactive
+            ./node_modules/.bin/firebase hosting:sites:create "${STATIC_SITE}" --project "${PROJECT_ID}" --non-interactive || {
+              echo "Failed to create hosting site ${STATIC_SITE}. Ensure the service account can manage hosting sites." >&2
+              exit 1
+            }
           fi
 
       - name: Deploy to Firebase preview channel
@@ -142,12 +150,23 @@ jobs:
           set -o errexit
           set -o pipefail
 
-          PROJECT_ARG=""
-          if [ -n "${FIREBASE_PROJECT_ID:-}" ]; then
-            PROJECT_ARG="--project ${FIREBASE_PROJECT_ID}"
+          PROJECT_ID="${FIREBASE_PROJECT_ID:-$FIREBASE_DEFAULT_PROJECT}"
+          if [ -z "${PROJECT_ID}" ]; then
+            echo "Missing Firebase project id" >&2
+            exit 1
           fi
 
-          ./node_modules/.bin/firebase hosting:channel:deploy "${PREVIEW_CHANNEL}" --json ${PROJECT_ARG} > firebase-deploy.json
+          ./node_modules/.bin/firebase hosting:channel:deploy "${PREVIEW_CHANNEL}" --project "${PROJECT_ID}" --json > firebase-deploy.json 2> firebase-deploy.log
+          STATUS=$?
+
+          if [ "${STATUS}" -ne 0 ]; then
+            echo "firebase hosting:channel:deploy failed" >&2
+            cat firebase-deploy.log >&2 || true
+            if [ -f firebase-deploy.json ]; then
+              cat firebase-deploy.json >&2
+            fi
+            exit ${STATUS}
+          fi
 
           node <<'NODE'
           const fs = require('fs');
@@ -208,6 +227,10 @@ jobs:
           set -o pipefail
 
           PROJECT_ID="${FIREBASE_PROJECT_ID:-$FIREBASE_DEFAULT_PROJECT}"
+          if [ -z "${PROJECT_ID}" ]; then
+            echo "Missing Firebase project id" >&2
+            exit 1
+          fi
           SOURCE_SITE="${PREVIEW_SOURCE_SITE}"
           STATIC_SITE="${PREVIEW_STATIC_SITE}"
 

--- a/firebase.json
+++ b/firebase.json
@@ -7,6 +7,7 @@
   },
   "hosting": [
     {
+      "site": "taca-da-pinga",
       "public": "dist",
       "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
       "headers": [

--- a/firebase.json
+++ b/firebase.json
@@ -38,7 +38,6 @@
     },
     {
       "target": "develop",
-      "site": "develop-taca-da-pinga",
       "public": "dist",
       "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
       "headers": [

--- a/firebase.json
+++ b/firebase.json
@@ -5,34 +5,68 @@
     "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"
   },
-  "hosting": {
-    "public": "dist",
-    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
-    "headers": [
-      {
-        "source": "**/*.@(js|css)",
-        "headers": [
-          {
-            "key": "Cache-Control",
-            "value": "public,max-age=31536000,immutable"
-          }
-        ]
-      },
-      {
-        "source": "**/*.@(png|jpg|jpeg|gif|svg|webp|ico|woff|woff2|ttf|eot)",
-        "headers": [
-          {
-            "key": "Cache-Control",
-            "value": "public,max-age=31536000,immutable"
-          }
-        ]
-      }
-    ],
-    "rewrites": [
-      {
-        "source": "**",
-        "destination": "/index.html"
-      }
-    ]
-  }
+  "hosting": [
+    {
+      "public": "dist",
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+      "headers": [
+        {
+          "source": "**/*.@(js|css)",
+          "headers": [
+            {
+              "key": "Cache-Control",
+              "value": "public,max-age=31536000,immutable"
+            }
+          ]
+        },
+        {
+          "source": "**/*.@(png|jpg|jpeg|gif|svg|webp|ico|woff|woff2|ttf|eot)",
+          "headers": [
+            {
+              "key": "Cache-Control",
+              "value": "public,max-age=31536000,immutable"
+            }
+          ]
+        }
+      ],
+      "rewrites": [
+        {
+          "source": "**",
+          "destination": "/index.html"
+        }
+      ]
+    },
+    {
+      "target": "develop",
+      "site": "develop-taca-da-pinga",
+      "public": "dist",
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+      "headers": [
+        {
+          "source": "**/*.@(js|css)",
+          "headers": [
+            {
+              "key": "Cache-Control",
+              "value": "public,max-age=31536000,immutable"
+            }
+          ]
+        },
+        {
+          "source": "**/*.@(png|jpg|jpeg|gif|svg|webp|ico|woff|woff2|ttf|eot)",
+          "headers": [
+            {
+              "key": "Cache-Control",
+              "value": "public,max-age=31536000,immutable"
+            }
+          ]
+        }
+      ],
+      "rewrites": [
+        {
+          "source": "**",
+          "destination": "/index.html"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## What

- add a GitHub Actions workflow that gates deploys with lint/tests/typecheck/build and pushes merges to `develop` to the `develop-taca-da-pinga` hosting target
- expand `firebase.json` to declare the `develop` hosting target that points at the dedicated site while keeping the existing rewrites/headers
- scope the existing CI workflow to PRs only so merges rely on the new deploy job

## Why

- merges to `develop` should go live automatically at https://develop-taca-da-pinga.web.app/
- the main CI job already runs for PRs; running it again on push would duplicate cost once the deploy workflow covers post-merge checks

## How

- mirror the PR pipeline (lint, test:ci, test:rules, typecheck, build) in `.github/workflows/deploy-develop.yml`, configure Firebase creds via existing secrets, then deploy `hosting:develop`
- convert `firebase.json` hosting config to an array and add a second entry with `target: "develop"` and `site: "develop-taca-da-pinga"`
- update `.github/workflows/ci.yml` to only run for PRs

## Checks

- [ ] Lint
- [ ] Typecheck
- [ ] Tests passing
- [ ] Docs updated (README/CHANGELOG if needed)
