### PR TITLE
docs: record ci and hosting automation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,10 @@ Purpose: This file briefs AI coding agents (e.g., Codex) on how to work in this 
 - Core rule: UI components MUST NOT call Firestore directly. All I/O goes through the `src/services/` layer.
 - Hosting: Firebase Hosting.
 - Node: 22.19.0.
+- Hosting sites:
+  - `taca-da-pinga` (main)
+  - `preview-taca-da-pinga` (PR previews)
+  - `develop-taca-da-pinga` (auto-deploy for develop)
 - Services: `src/services/leaderboard.js` (getLeaderboard, observeLeaderboard, addPinga, listEvents), `src/services/teams.js` (observeTeamsOrderedByName, createTeamIfNotExists, deleteTeam).
 
 ## Branching & PR Rules
@@ -134,6 +138,10 @@ src/
 - Job should: install, lint, typecheck, test (CI mode), build.
 
 - Your PR must pass CI before merge.
+- Additional workflows:
+  - PR preview deployment (`pr-preview.yml`) builds PRs and refreshes `https://preview-taca-da-pinga.web.app`.
+  - Develop deploy (`deploy-develop.yml`) reruns the full suite on merge and deploys to `https://develop-taca-da-pinga.web.app`.
+- Required secrets (set once in GitHub → Settings → Secrets): the `VITE_FIREBASE_*` client config, `FIREBASE_SERVICE_ACCOUNT` (with Firebase Hosting Admin + Firebase Rules Admin), and optionally `FIREBASE_PROJECT_ID` if the default differs.
 
 ## Rollout & Rollback
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ npm run test:rules  # Firestore security rules (emulator)
 - Into `production`: CI must be green **and** at least 1 approval from code owner.
 - Required CI check name: **CI / Lint / Typecheck / Test / Build**
 
+### CI & Deployments
+
+- **PR Preview** – Every pull request builds the app in GitHub Actions and publishes a Firebase Hosting preview at [`https://preview-taca-da-pinga.web.app`](https://preview-taca-da-pinga.web.app). The job reuses the preview channel, so reruns refresh the same URL.
+- **Deploy Develop** – Merges to `develop` rerun lint/test/typecheck/build and deploy the bundle to the dedicated Hosting site [`https://develop-taca-da-pinga.web.app`](https://develop-taca-da-pinga.web.app).
+- Both workflows require the Firebase web config secrets (`VITE_FIREBASE_*`) and a `FIREBASE_SERVICE_ACCOUNT` with Hosting + Rules deploy permissions. See [docs/CONFIG.md](docs/CONFIG.md#github-secrets) for the list.
+
 See [`AGENTS.md`](./AGENTS.md) for exact agent/developer workflows.
 
 ---

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -13,6 +13,23 @@ VITE_FIREBASE_MESSAGING_SENDER_ID=
 VITE_FIREBASE_APP_ID=
 ```
 
+## GitHub Secrets
+
+The CI/CD workflows rely on the same Firebase configuration. Add these repository secrets:
+
+| Secret                              | Required | Description                                                                      |
+| ----------------------------------- | -------- | -------------------------------------------------------------------------------- |
+| `VITE_FIREBASE_API_KEY`             | ✅       | Firebase client config (same value as local dev)                                 |
+| `VITE_FIREBASE_AUTH_DOMAIN`         | ✅       | Firebase client config                                                           |
+| `VITE_FIREBASE_PROJECT_ID`          | ✅       | Firebase client config + default project fallback                                |
+| `VITE_FIREBASE_STORAGE_BUCKET`      | ✅       | Firebase client config                                                           |
+| `VITE_FIREBASE_MESSAGING_SENDER_ID` | ✅       | Firebase client config                                                           |
+| `VITE_FIREBASE_APP_ID`              | ✅       | Firebase client config                                                           |
+| `FIREBASE_SERVICE_ACCOUNT`          | ✅       | Base64/JSON service account with Hosting + Firestore Rules deploy permissions    |
+| `FIREBASE_PROJECT_ID`               | ⬜       | Override when the repo default project differs from the service account defaults |
+
+> The service account must be able to create Hosting channels/sites and deploy Firestore rules (e.g. roles: `Firebase Hosting Admin` + `Firebase Rules Admin`).
+
 ## Runtime Config
 
 - Admin allowlist: `app_config/admins` document in Firestore (or custom claim `admin`).

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -42,6 +42,20 @@ Dev test user (local only): testing@tests.com / testing
 
 - Build: yarn build (outputs to dist/). Use `yarn preview` to preview the production build.
 
+## CI / Hosting Pipelines
+
+- **PR Preview** (`.github/workflows/pr-preview.yml`)
+  - Runs on every pull request and manual dispatch.
+  - Installs deps, builds, deploys `hosting:preview` and clones the release to the static site `preview-taca-da-pinga.web.app`.
+  - Useful for reviewers: the workflow comments the refreshable preview URL on the PR.
+
+- **Deploy Develop** (`.github/workflows/deploy-develop.yml`)
+  - Runs on every push to `develop`.
+  - Executes lint → `test:ci` → `test:rules` → `typecheck` → `build` before deploying `hosting:develop` (site `develop-taca-da-pinga`).
+  - The deploy step assumes `FIREBASE_SERVICE_ACCOUNT` can publish Hosting releases and Firestore rules.
+
+Inspect failed runs in GitHub → Actions. Most failures stem from missing secrets or insufficient Firebase IAM roles.
+
 ## Admin (custom claims)
 
 Admin-only Firestore writes are protected by a custom claim: `admin: true`.  

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,5 +1,11 @@
 # Release & Rollback
 
+## Automation Overview
+
+- Pull requests automatically publish previews at `https://preview-taca-da-pinga.web.app`.
+- Merges to `develop` auto-deploy to `https://develop-taca-da-pinga.web.app` after re-running lint/tests/build.
+- Production deploys remain manual (below).
+
 ## Pre-merge to `production`
 
 - [ ] CI green on `develop`
@@ -12,6 +18,8 @@ firebase use <prod-project-id>
 yarn build
 firebase deploy --only hosting,firestore:rules,firestore:indexes
 ```
+
+> The service account used by the automation must have permission to deploy Hosting **and** Firestore rules (e.g. Firebase Hosting Admin + Firebase Rules Admin). Grant the same roles locally (or run deploys with an owner account) to avoid 403 errors.
 
 ## Rollback
 


### PR DESCRIPTION
## What

- document the PR preview and develop auto-deploy workflows across README, DEV, RELEASE and agent notes
- outline required GitHub secrets and IAM roles so the Firebase actions keep working

## Why

- we shipped new CI/hosting automation without capturing the setup steps and URLs anywhere
- future contributors need a single reference for secrets, permissions, and where to find preview builds

## How

- add a "CI & Deployments" section to README and a pipelines section in docs/DEV.md
- extend docs/CONFIG.md with the GitHub secrets table and note required Firebase roles
- update docs/RELEASE.md and AGENTS.md with automation overview, hosting site IDs, and workflow summaries

## Checks

- [ ] Lint
- [ ] Typecheck
- [ ] Tests passing
- [ ] Docs updated (README/CHANGELOG if needed)
