### PR TITLE
fix: align Firestore team index definition

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -25,10 +25,6 @@
         {
           "fieldPath": "name",
           "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "__name__",
-          "order": "ASCENDING"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- remove the explicit `__name__` field from the `teams` composite index
- align `firestore.indexes.json` with the already deployed Firestore index so CI does not attempt to create a duplicate

## Validation
- parsed `firestore.indexes.json` successfully
- `git diff --check` passed

## Deployment context
The develop deploy reached Firestore successfully after the IAM fix, but failed with HTTP 409 because the explicit `__name__` definition was treated as a separate index while an equivalent index already existed.