### PR TITLE
feat: add responsive leaderboard comparison bars

### DIFF
--- a/src/components/LeaderboardRow.module.css
+++ b/src/components/LeaderboardRow.module.css
@@ -126,8 +126,8 @@
 
 @media (min-width: 75rem) and (max-width: 89.9375rem) {
   .rankBadge {
-    min-width: 1.875rem;
-    height: 1.875rem;
+    min-width: 2.125rem;
+    height: 2.125rem;
     padding: 0 var(--ui-space-2xs);
     font-size: 1rem;
   }

--- a/src/components/LeaderboardRow.module.css
+++ b/src/components/LeaderboardRow.module.css
@@ -3,9 +3,9 @@
   display: grid;
   grid-template-columns: var(
     --leaderboard-grid-template,
-    minmax(3.25rem, 3.75rem) minmax(0, 1fr) clamp(6rem, 16vw, 8rem)
+    minmax(3.25rem, 3.75rem) minmax(10rem, 0.7fr) minmax(0, 1.3fr)
   );
-  column-gap: var(--ui-space-xs);
+  column-gap: var(--leaderboard-column-gap, var(--ui-space-md));
   align-items: center;
   width: 100%;
   min-width: 0;
@@ -25,7 +25,7 @@
   position: absolute;
   inset: 0 auto 0 0;
   width: 4px;
-  background: var(--row-meter-fill-start, var(--ui-color-accent));
+  background: var(--row-accent, var(--ui-color-accent));
   z-index: 0;
 }
 
@@ -35,7 +35,7 @@
 
 .rankCell,
 .teamCell,
-.scoreCell {
+.meterCell {
   position: relative;
   z-index: 1;
   display: flex;
@@ -63,9 +63,9 @@
 }
 
 .teamCell {
-  flex-direction: row;
+  flex-direction: column;
   align-items: flex-start;
-  gap: var(--ui-space-sm);
+  justify-content: center;
   min-width: 0;
 }
 
@@ -80,7 +80,17 @@
 }
 
 .meter {
-  display: none;
+  position: relative;
+  width: 100%;
+  height: 0.75rem;
+  overflow: hidden;
+  border-radius: var(--ui-radius-full);
+  background: rgba(148, 163, 184, 0.2);
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.08);
+}
+
+.meterCell {
+  min-width: 0;
 }
 
 .meterFill {
@@ -88,46 +98,43 @@
   top: 0;
   left: 0;
   bottom: 0;
-  width: 0%;
+  width: var(--row-fill-width, 0%);
+  border-radius: inherit;
   background: linear-gradient(
     90deg,
-    var(--row-meter-fill-start, rgba(34, 197, 94, 0.75)),
-    var(--row-meter-fill-end, rgba(15, 118, 110, 0.85))
+    var(--row-meter-start, var(--ui-color-accent-strong)) 0%,
+    var(--row-meter-end, var(--ui-color-accent)) 100%
   );
-  transition: width 220ms ease;
+  box-shadow:
+    0 1px 2px var(--row-meter-shadow, rgba(4, 120, 87, 0.28)),
+    inset 0 1px 0 rgba(255, 255, 255, 0.28);
+  transition: width 240ms ease-out;
 }
 
-.scoreCell {
-  flex-direction: row;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 0.35rem;
-  text-align: right;
-  min-width: 0;
+.meterFill::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.16), transparent 65%);
 }
 
-.scoreValue {
-  font-size: 1.35rem;
-  font-weight: var(--ui-font-weight-extrabold);
-  font-variant-numeric: tabular-nums;
-  color: var(--row-score-color, var(--ui-color-text-primary));
-  min-width: 0;
-}
-
-.scoreIcon {
-  display: block;
-  width: 1.4rem;
-  height: 1.4rem;
-  flex: 0 0 auto;
-  object-fit: contain;
+@media (prefers-reduced-motion: reduce) {
+  .meterFill {
+    transition: none;
+  }
 }
 
 @media (max-width: 640px) {
   .root {
+    grid-template-columns: 2.25rem minmax(0, 1fr);
+    grid-template-rows: min-content min-content;
+    align-content: center;
+    align-items: center;
+    row-gap: 0.4rem;
     height: 64px;
-    padding-left: var(--ui-space-xs);
-    padding-right: var(--ui-space-xs);
-    column-gap: var(--ui-space-2xs);
+    padding-left: var(--ui-space-sm);
+    padding-right: var(--ui-space-sm);
+    column-gap: var(--ui-space-sm);
   }
 
   .rankBadge {
@@ -138,14 +145,30 @@
 
   .teamName {
     font-size: 1rem;
+    line-height: 1.2;
   }
 
-  .scoreValue {
-    font-size: 1rem;
+  .rankCell {
+    grid-row: 1 / -1;
   }
 
-  .scoreIcon {
-    width: 1.05rem;
-    height: 1.05rem;
+  .teamCell,
+  .meterCell {
+    grid-column: 2;
+  }
+
+  .teamCell {
+    grid-row: 1;
+    justify-content: center;
+    align-self: end;
+  }
+
+  .meterCell {
+    grid-row: 2;
+    align-self: start;
+  }
+
+  .meter {
+    height: 0.625rem;
   }
 }

--- a/src/components/LeaderboardRow.module.css
+++ b/src/components/LeaderboardRow.module.css
@@ -3,13 +3,13 @@
   display: grid;
   grid-template-columns: var(
     --leaderboard-grid-template,
-    minmax(3.25rem, 3.75rem) minmax(10rem, 0.7fr) minmax(0, 1.3fr)
+    minmax(3.25rem, 3.75rem) minmax(clamp(8rem, 18vw, 12rem), 0.7fr) minmax(0, 1.3fr)
   );
   column-gap: var(--leaderboard-column-gap, var(--ui-space-md));
   align-items: center;
   width: 100%;
   min-width: 0;
-  height: var(--leaderboard-row-height, 80px);
+  height: var(--leaderboard-row-height, 5rem);
   padding: 0 var(--ui-space-md);
   border-radius: var(--ui-radius-sm);
   background: var(--ui-color-surface);
@@ -24,7 +24,7 @@
   content: '';
   position: absolute;
   inset: 0 auto 0 0;
-  width: 4px;
+  width: 0.25rem;
   background: var(--row-accent, var(--ui-color-accent));
   z-index: 0;
 }
@@ -124,6 +124,23 @@
   }
 }
 
+@media (min-width: 75rem) and (max-width: 89.9375rem) {
+  .rankBadge {
+    min-width: 1.875rem;
+    height: 1.875rem;
+    padding: 0 var(--ui-space-2xs);
+    font-size: 1rem;
+  }
+
+  .teamName {
+    font-size: 1rem;
+  }
+
+  .meter {
+    height: 0.625rem;
+  }
+}
+
 @media (max-width: 640px) {
   .root {
     grid-template-columns: 2.25rem minmax(0, 1fr);
@@ -131,7 +148,7 @@
     align-content: center;
     align-items: center;
     row-gap: 0.4rem;
-    height: 64px;
+    height: 4rem;
     padding-left: var(--ui-space-sm);
     padding-right: var(--ui-space-sm);
     column-gap: var(--ui-space-sm);

--- a/src/components/LeaderboardRow.tsx
+++ b/src/components/LeaderboardRow.tsx
@@ -1,8 +1,5 @@
 import type { CSSProperties } from 'react';
-import beerIcon from '../assets/beer.svg';
 import styles from './LeaderboardRow.module.css';
-
-const fallbackFormatter = new Intl.NumberFormat('pt-PT');
 
 type LeaderboardRowTone = {
   accent: string;
@@ -10,7 +7,7 @@ type LeaderboardRowTone = {
   badgeColor: string;
   meterStart: string;
   meterEnd: string;
-  scoreColor: string;
+  meterShadow: string;
 };
 
 type LeaderboardRowProps = {
@@ -19,7 +16,6 @@ type LeaderboardRowProps = {
   pingas: number;
   maxPingas: number;
   ariaRowIndex: number;
-  numberFormatter?: Intl.NumberFormat;
 };
 
 const getTone = (rank: number): LeaderboardRowTone => {
@@ -29,36 +25,36 @@ const getTone = (rank: number): LeaderboardRowTone => {
         accent: 'rgba(250, 204, 21, 0.32)',
         badgeBg: 'rgba(250, 204, 21, 0.38)',
         badgeColor: '#854d0e',
-        meterStart: '#facc15',
-        meterEnd: '#f59e0b',
-        scoreColor: '#ca8a04',
+        meterStart: '#d97706',
+        meterEnd: '#facc15',
+        meterShadow: 'rgba(180, 83, 9, 0.28)',
       };
     case 2:
       return {
         accent: 'rgba(148, 163, 184, 0.28)',
         badgeBg: 'rgba(226, 232, 240, 0.6)',
         badgeColor: '#1f2937',
-        meterStart: '#cbd5f5',
-        meterEnd: '#94a3b8',
-        scoreColor: '#64748b',
+        meterStart: '#64748b',
+        meterEnd: '#cbd5e1',
+        meterShadow: 'rgba(71, 85, 105, 0.24)',
       };
     case 3:
       return {
         accent: 'rgba(249, 115, 22, 0.25)',
         badgeBg: 'rgba(253, 186, 116, 0.5)',
         badgeColor: '#7c2d12',
-        meterStart: '#fb923c',
-        meterEnd: '#f97316',
-        scoreColor: '#c2410c',
+        meterStart: '#c2410c',
+        meterEnd: '#fb923c',
+        meterShadow: 'rgba(154, 52, 18, 0.26)',
       };
     default:
       return {
         accent: 'rgba(34, 197, 94, 0.2)',
         badgeBg: 'rgba(16, 185, 129, 0.18)',
         badgeColor: '#065f46',
-        meterStart: '#22c55e',
-        meterEnd: '#0f766e',
-        scoreColor: '#0f172a',
+        meterStart: '#047857',
+        meterEnd: '#22c55e',
+        meterShadow: 'rgba(4, 120, 87, 0.28)',
       };
   }
 };
@@ -81,12 +77,11 @@ export function LeaderboardRow({
   pingas,
   maxPingas,
   ariaRowIndex,
-  numberFormatter,
 }: LeaderboardRowProps) {
-  const formatter = numberFormatter ?? fallbackFormatter;
   const safePingas = Number.isFinite(pingas) ? Math.max(0, Math.floor(pingas)) : 0;
-  const safeMax = Math.max(maxPingas, safePingas, 0);
+  const safeMax = Number.isFinite(maxPingas) ? Math.max(0, Math.floor(maxPingas)) : 0;
   const fillPercent = safeMax > 0 ? clampPercentage((safePingas / safeMax) * 100) : 0;
+  const roundedFillPercent = Math.round(fillPercent);
   const tone = getTone(rank);
 
   const style = {
@@ -94,13 +89,17 @@ export function LeaderboardRow({
     '--row-accent': tone.accent,
     '--row-rank-bg': tone.badgeBg,
     '--row-rank-color': tone.badgeColor,
-    '--row-meter-fill-start': tone.meterStart,
-    '--row-meter-fill-end': tone.meterEnd,
-    '--row-score-color': tone.scoreColor,
+    '--row-meter-start': tone.meterStart,
+    '--row-meter-end': tone.meterEnd,
+    '--row-meter-shadow': tone.meterShadow,
   } as CSSProperties;
 
-  const scoreText = formatter.format(safePingas);
-  const ariaValueMax = safeMax === 0 ? 0 : safeMax;
+  const ariaValueText =
+    safeMax === 0
+      ? `${teamName} ainda não tem valor registado`
+      : roundedFillPercent === 100
+        ? `${teamName} está no valor de referência`
+        : `${teamName} está a ${roundedFillPercent}% do valor da equipa líder`;
 
   return (
     <div
@@ -119,26 +118,18 @@ export function LeaderboardRow({
         <span className={styles.teamName} title={teamName}>
           {teamName}
         </span>
+      </div>
+      <div role="cell" className={styles.meterCell}>
         <div
           className={styles.meter}
           role="meter"
           aria-valuemin={0}
-          aria-valuenow={safePingas}
-          aria-valuemax={ariaValueMax}
-          aria-valuetext={`${teamName} tem ${scoreText} pingas`}
+          aria-valuenow={roundedFillPercent}
+          aria-valuemax={100}
+          aria-valuetext={ariaValueText}
         >
-          <div className={styles.meterFill} style={{ width: `${fillPercent}%` }} aria-hidden />
+          <div className={styles.meterFill} aria-hidden="true" />
         </div>
-      </div>
-      <div role="cell" className={styles.scoreCell}>
-        <span className={styles.scoreValue}>{scoreText}</span>
-        <img
-          className={styles.scoreIcon}
-          src={beerIcon}
-          alt=""
-          aria-hidden="true"
-          data-testid="score-beer-icon"
-        />
       </div>
     </div>
   );

--- a/src/components/LeaderboardRow.tsx
+++ b/src/components/LeaderboardRow.tsx
@@ -68,7 +68,7 @@ const clampPercentage = (value: number) => {
     return 100;
   }
 
-  return Math.max(0, value);
+  return value;
 };
 
 export function LeaderboardRow({

--- a/src/components/LeaderboardRow.tsx
+++ b/src/components/LeaderboardRow.tsx
@@ -81,7 +81,8 @@ export function LeaderboardRow({
   const safePingas = Number.isFinite(pingas) ? Math.max(0, Math.floor(pingas)) : 0;
   const safeMax = Number.isFinite(maxPingas) ? Math.max(0, Math.floor(maxPingas)) : 0;
   const fillPercent = safeMax > 0 ? clampPercentage((safePingas / safeMax) * 100) : 0;
-  const roundedFillPercent = Math.round(fillPercent);
+  const isReferenceValue = safeMax > 0 && safePingas === safeMax;
+  const roundedFillPercent = isReferenceValue ? 100 : Math.min(99, Math.round(fillPercent));
   const tone = getTone(rank);
 
   const style = {

--- a/src/components/SponsorMarquee.module.css
+++ b/src/components/SponsorMarquee.module.css
@@ -45,6 +45,13 @@
   touch-action: pan-y;
   user-select: none;
   -webkit-user-drag: none;
+  -webkit-mask-image: linear-gradient(
+    to right,
+    transparent,
+    #000 1rem,
+    #000 calc(100% - 1rem),
+    transparent
+  );
   mask-image: linear-gradient(
     to right,
     transparent,
@@ -171,12 +178,6 @@
   .animatedRow .track {
     animation: none;
     transform: none;
-  }
-}
-
-@media (hover: none) {
-  .animatedRow {
-    mask-image: none;
   }
 }
 

--- a/src/components/SponsorsRail.jsx
+++ b/src/components/SponsorsRail.jsx
@@ -90,6 +90,12 @@ export default function SponsorsRail({
       return undefined;
     }
 
+    if (prefersReducedMotion) {
+      loopProgressRef.current = 0;
+      track.style.transform = '';
+      return undefined;
+    }
+
     let frameId = 0;
     let previousTime;
     let offset = loopProgressRef.current * cycleExtent;
@@ -115,7 +121,7 @@ export default function SponsorsRail({
 
     applyOffset();
 
-    if (isPaused || prefersReducedMotion) {
+    if (isPaused) {
       return () => {
         loopProgressRef.current = offset / cycleExtent;
       };

--- a/src/components/SponsorsRail.jsx
+++ b/src/components/SponsorsRail.jsx
@@ -16,6 +16,7 @@ export default function SponsorsRail({
 }) {
   const viewportRef = React.useRef(null);
   const cycleRef = React.useRef(null);
+  const isPausedRef = React.useRef(false);
   const items = React.useMemo(
     () =>
       sponsors.length
@@ -50,21 +51,55 @@ export default function SponsorsRail({
 
     return nextCycle;
   }, [cycleLength, items]);
-  const { copies, durationSeconds } = useMeasuredLoop({
+  const { copies, cycleExtent } = useMeasuredLoop({
     axis: 'y',
     cycleRef,
     enabled: shouldLoop,
     pixelsPerSecond: AUTO_SCROLL_SPEED,
     viewportRef,
   });
-  const loopStyle = shouldLoop
-    ? {
-        '--loop-distance': `-${100 / copies}%`,
-        '--loop-duration': durationSeconds ? `${durationSeconds}s` : undefined,
+
+  React.useEffect(() => {
+    if (!shouldLoop || !cycleExtent) return undefined;
+
+    const viewport = viewportRef.current;
+    if (!viewport) return undefined;
+
+    const reducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)');
+    let frameId;
+    let previousTime;
+    let offset = viewport.scrollTop % cycleExtent;
+
+    const tick = (time) => {
+      if (previousTime === undefined) previousTime = time;
+
+      const elapsedSeconds = (time - previousTime) / 1000;
+      previousTime = time;
+
+      if (!isPausedRef.current && !reducedMotion?.matches) {
+        offset = (offset + elapsedSeconds * AUTO_SCROLL_SPEED) % cycleExtent;
+        viewport.scrollTop = offset;
       }
-    : undefined;
+
+      frameId = window.requestAnimationFrame(tick);
+    };
+
+    frameId = window.requestAnimationFrame(tick);
+
+    return () => window.cancelAnimationFrame(frameId);
+  }, [copies, cycleExtent, shouldLoop]);
 
   if (!items.length) return null;
+
+  const pauseLoop = () => {
+    isPausedRef.current = true;
+  };
+
+  const resumeLoop = (event) => {
+    if (event.currentTarget.contains(event.relatedTarget)) return;
+
+    isPausedRef.current = false;
+  };
 
   const renderItem = (item, index, isDuplicate) => {
     const content = (
@@ -124,12 +159,18 @@ export default function SponsorsRail({
   };
 
   return (
-    <aside className={`${styles.rail} ${side === 'right' ? styles.right : styles.left}`}>
+    <aside
+      className={`${styles.rail} ${side === 'right' ? styles.right : styles.left}`}
+      onMouseEnter={pauseLoop}
+      onMouseLeave={resumeLoop}
+      onFocusCapture={pauseLoop}
+      onBlurCapture={resumeLoop}
+    >
       <div
         ref={viewportRef}
         className={`${styles.viewport} ${shouldLoop ? styles.animatedViewport : ''}`}
       >
-        <div className={styles.stack} style={loopStyle}>
+        <div className={styles.stack}>
           {Array.from({ length: shouldLoop ? copies : 1 }, (_, cycleIndex) =>
             renderCycle(cycleIndex)
           )}

--- a/src/components/SponsorsRail.jsx
+++ b/src/components/SponsorsRail.jsx
@@ -104,7 +104,7 @@ export default function SponsorsRail({
       window.cancelAnimationFrame(frameId);
       track.style.transform = '';
     };
-  }, [copies, cycleExtent, shouldLoop]);
+  }, [cycleExtent, shouldLoop]);
 
   if (!items.length) return null;
 

--- a/src/components/SponsorsRail.jsx
+++ b/src/components/SponsorsRail.jsx
@@ -17,8 +17,13 @@ export default function SponsorsRail({
   const viewportRef = React.useRef(null);
   const cycleRef = React.useRef(null);
   const trackRef = React.useRef(null);
-  const isPausedRef = React.useRef(false);
   const loopProgressRef = React.useRef(0);
+  const [isPaused, setIsPaused] = React.useState(false);
+  const [prefersReducedMotion, setPrefersReducedMotion] = React.useState(() =>
+    typeof window !== 'undefined' && window.matchMedia
+      ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+      : false
+  );
   const items = React.useMemo(
     () =>
       sponsors.length
@@ -60,17 +65,31 @@ export default function SponsorsRail({
     pixelsPerSecond: AUTO_SCROLL_SPEED,
     viewportRef,
   });
+
   React.useEffect(() => {
-    if (!shouldLoop || !cycleExtent) {
+    const mediaQuery = window.matchMedia?.('(prefers-reduced-motion: reduce)');
+    if (!mediaQuery) {
       return undefined;
     }
 
+    const updatePreference = () => setPrefersReducedMotion(mediaQuery.matches);
+    updatePreference();
+    mediaQuery.addEventListener?.('change', updatePreference);
+
+    return () => mediaQuery.removeEventListener?.('change', updatePreference);
+  }, []);
+
+  React.useEffect(() => {
     const track = trackRef.current;
     if (!track) {
       return undefined;
     }
 
-    const reducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)');
+    if (!shouldLoop || !cycleExtent) {
+      track.style.transform = '';
+      return undefined;
+    }
+
     let frameId = 0;
     let previousTime;
     let offset = loopProgressRef.current * cycleExtent;
@@ -87,37 +106,48 @@ export default function SponsorsRail({
       const elapsedSeconds = Math.min((time - previousTime) / 1000, 0.05);
       previousTime = time;
 
-      if (!isPausedRef.current && !reducedMotion?.matches) {
-        offset = (offset + elapsedSeconds * AUTO_SCROLL_SPEED) % cycleExtent;
-        loopProgressRef.current = offset / cycleExtent;
-        applyOffset();
-      }
+      offset = (offset + elapsedSeconds * AUTO_SCROLL_SPEED) % cycleExtent;
+      loopProgressRef.current = offset / cycleExtent;
+      applyOffset();
 
       frameId = window.requestAnimationFrame(tick);
     };
 
     applyOffset();
+
+    if (isPaused || prefersReducedMotion) {
+      return () => {
+        loopProgressRef.current = offset / cycleExtent;
+      };
+    }
+
     frameId = window.requestAnimationFrame(tick);
 
     return () => {
       loopProgressRef.current = offset / cycleExtent;
       window.cancelAnimationFrame(frameId);
-      track.style.transform = '';
     };
-  }, [cycleExtent, shouldLoop]);
+  }, [cycleExtent, isPaused, prefersReducedMotion, shouldLoop]);
+
+  React.useEffect(
+    () => () => {
+      trackRef.current?.style.removeProperty('transform');
+    },
+    []
+  );
 
   if (!items.length) return null;
 
   const pauseLoop = () => {
-    isPausedRef.current = true;
+    setIsPaused(true);
   };
 
   const resumeLoop = (event) => {
-    if (event.currentTarget.contains(event.relatedTarget)) {
+    if (event.relatedTarget instanceof Node && event.currentTarget.contains(event.relatedTarget)) {
       return;
     }
 
-    isPausedRef.current = false;
+    setIsPaused(false);
   };
 
   const renderItem = (item, index, isDuplicate) => {

--- a/src/components/SponsorsRail.jsx
+++ b/src/components/SponsorsRail.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import useInteractiveLoop from '../hooks/useInteractiveLoop';
 import useMeasuredLoop from '../hooks/useMeasuredLoop';
 import styles from './SponsorsRail.module.css';
 
@@ -16,7 +17,7 @@ export default function SponsorsRail({
 }) {
   const viewportRef = React.useRef(null);
   const cycleRef = React.useRef(null);
-  const isPausedRef = React.useRef(false);
+  const trackRef = React.useRef(null);
   const items = React.useMemo(
     () =>
       sponsors.length
@@ -51,55 +52,22 @@ export default function SponsorsRail({
 
     return nextCycle;
   }, [cycleLength, items]);
-  const { copies, cycleExtent } = useMeasuredLoop({
+  const { copies, cycleExtent, durationSeconds } = useMeasuredLoop({
     axis: 'y',
     cycleRef,
     enabled: shouldLoop,
     pixelsPerSecond: AUTO_SCROLL_SPEED,
     viewportRef,
   });
-
-  React.useEffect(() => {
-    if (!shouldLoop || !cycleExtent) return undefined;
-
-    const viewport = viewportRef.current;
-    if (!viewport) return undefined;
-
-    const reducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)');
-    let frameId;
-    let previousTime;
-    let offset = viewport.scrollTop % cycleExtent;
-
-    const tick = (time) => {
-      if (previousTime === undefined) previousTime = time;
-
-      const elapsedSeconds = (time - previousTime) / 1000;
-      previousTime = time;
-
-      if (!isPausedRef.current && !reducedMotion?.matches) {
-        offset = (offset + elapsedSeconds * AUTO_SCROLL_SPEED) % cycleExtent;
-        viewport.scrollTop = offset;
-      }
-
-      frameId = window.requestAnimationFrame(tick);
-    };
-
-    frameId = window.requestAnimationFrame(tick);
-
-    return () => window.cancelAnimationFrame(frameId);
-  }, [copies, cycleExtent, shouldLoop]);
+  const interactionHandlers = useInteractiveLoop({
+    axis: 'y',
+    cycleExtent,
+    durationSeconds,
+    enabled: shouldLoop,
+    trackRef,
+  });
 
   if (!items.length) return null;
-
-  const pauseLoop = () => {
-    isPausedRef.current = true;
-  };
-
-  const resumeLoop = (event) => {
-    if (event.currentTarget.contains(event.relatedTarget)) return;
-
-    isPausedRef.current = false;
-  };
 
   const renderItem = (item, index, isDuplicate) => {
     const content = (
@@ -161,16 +129,13 @@ export default function SponsorsRail({
   return (
     <aside
       className={`${styles.rail} ${side === 'right' ? styles.right : styles.left}`}
-      onMouseEnter={pauseLoop}
-      onMouseLeave={resumeLoop}
-      onFocusCapture={pauseLoop}
-      onBlurCapture={resumeLoop}
+      {...interactionHandlers}
     >
       <div
         ref={viewportRef}
         className={`${styles.viewport} ${shouldLoop ? styles.animatedViewport : ''}`}
       >
-        <div className={styles.stack}>
+        <div ref={trackRef} className={styles.stack}>
           {Array.from({ length: shouldLoop ? copies : 1 }, (_, cycleIndex) =>
             renderCycle(cycleIndex)
           )}

--- a/src/components/SponsorsRail.jsx
+++ b/src/components/SponsorsRail.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import useInteractiveLoop from '../hooks/useInteractiveLoop';
 import useMeasuredLoop from '../hooks/useMeasuredLoop';
 import styles from './SponsorsRail.module.css';
 
@@ -18,6 +17,8 @@ export default function SponsorsRail({
   const viewportRef = React.useRef(null);
   const cycleRef = React.useRef(null);
   const trackRef = React.useRef(null);
+  const isPausedRef = React.useRef(false);
+  const loopProgressRef = React.useRef(0);
   const items = React.useMemo(
     () =>
       sponsors.length
@@ -52,22 +53,72 @@ export default function SponsorsRail({
 
     return nextCycle;
   }, [cycleLength, items]);
-  const { copies, cycleExtent, durationSeconds } = useMeasuredLoop({
+  const { copies, cycleExtent } = useMeasuredLoop({
     axis: 'y',
     cycleRef,
     enabled: shouldLoop,
     pixelsPerSecond: AUTO_SCROLL_SPEED,
     viewportRef,
   });
-  const interactionHandlers = useInteractiveLoop({
-    axis: 'y',
-    cycleExtent,
-    durationSeconds,
-    enabled: shouldLoop,
-    trackRef,
-  });
+  React.useEffect(() => {
+    if (!shouldLoop || !cycleExtent) {
+      return undefined;
+    }
+
+    const track = trackRef.current;
+    if (!track) {
+      return undefined;
+    }
+
+    const reducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)');
+    let frameId = 0;
+    let previousTime;
+    let offset = loopProgressRef.current * cycleExtent;
+
+    const applyOffset = () => {
+      track.style.transform = `translate3d(0, -${offset}px, 0)`;
+    };
+
+    const tick = (time) => {
+      if (previousTime === undefined) {
+        previousTime = time;
+      }
+
+      const elapsedSeconds = Math.min((time - previousTime) / 1000, 0.05);
+      previousTime = time;
+
+      if (!isPausedRef.current && !reducedMotion?.matches) {
+        offset = (offset + elapsedSeconds * AUTO_SCROLL_SPEED) % cycleExtent;
+        loopProgressRef.current = offset / cycleExtent;
+        applyOffset();
+      }
+
+      frameId = window.requestAnimationFrame(tick);
+    };
+
+    applyOffset();
+    frameId = window.requestAnimationFrame(tick);
+
+    return () => {
+      loopProgressRef.current = offset / cycleExtent;
+      window.cancelAnimationFrame(frameId);
+      track.style.transform = '';
+    };
+  }, [copies, cycleExtent, shouldLoop]);
 
   if (!items.length) return null;
+
+  const pauseLoop = () => {
+    isPausedRef.current = true;
+  };
+
+  const resumeLoop = (event) => {
+    if (event.currentTarget.contains(event.relatedTarget)) {
+      return;
+    }
+
+    isPausedRef.current = false;
+  };
 
   const renderItem = (item, index, isDuplicate) => {
     const content = (
@@ -129,7 +180,10 @@ export default function SponsorsRail({
   return (
     <aside
       className={`${styles.rail} ${side === 'right' ? styles.right : styles.left}`}
-      {...interactionHandlers}
+      onMouseEnter={pauseLoop}
+      onMouseLeave={resumeLoop}
+      onFocusCapture={pauseLoop}
+      onBlurCapture={resumeLoop}
     >
       <div
         ref={viewportRef}

--- a/src/components/SponsorsRail.module.css
+++ b/src/components/SponsorsRail.module.css
@@ -18,7 +18,29 @@
 }
 
 .animatedViewport {
+  position: relative;
   overflow-y: hidden;
+}
+
+.animatedViewport::before,
+.animatedViewport::after {
+  content: '';
+  position: absolute;
+  z-index: 1;
+  right: 0;
+  left: 0;
+  height: 1rem;
+  pointer-events: none;
+}
+
+.animatedViewport::before {
+  top: 0;
+  background: linear-gradient(to bottom, var(--ui-color-page), transparent);
+}
+
+.animatedViewport::after {
+  bottom: 0;
+  background: linear-gradient(to top, var(--ui-color-page), transparent);
 }
 
 .viewport::-webkit-scrollbar {

--- a/src/components/SponsorsRail.module.css
+++ b/src/components/SponsorsRail.module.css
@@ -19,6 +19,21 @@
 
 .animatedViewport {
   overflow-y: hidden;
+  --rail-edge-fade-size: 1.25rem;
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    transparent,
+    #000 var(--rail-edge-fade-size),
+    #000 calc(100% - var(--rail-edge-fade-size)),
+    transparent
+  );
+  mask-image: linear-gradient(
+    to bottom,
+    transparent,
+    #000 var(--rail-edge-fade-size),
+    #000 calc(100% - var(--rail-edge-fade-size)),
+    transparent
+  );
 }
 
 .viewport::-webkit-scrollbar {

--- a/src/components/SponsorsRail.module.css
+++ b/src/components/SponsorsRail.module.css
@@ -60,22 +60,6 @@
   padding-bottom: 0.875rem;
 }
 
-.animatedViewport .stack {
-  animation: sponsors-rail var(--loop-duration, 30s) linear infinite;
-  will-change: transform;
-}
-
-.animatedViewport:hover .stack,
-.animatedViewport:focus-within .stack {
-  animation-play-state: paused;
-}
-
-@keyframes sponsors-rail {
-  to {
-    transform: translate3d(0, var(--loop-distance), 0);
-  }
-}
-
 .slot {
   display: flex;
   flex-direction: column;
@@ -197,10 +181,5 @@
 @media (prefers-reduced-motion: reduce) {
   .animatedViewport {
     overflow-y: auto;
-  }
-
-  .animatedViewport .stack {
-    animation: none;
-    transform: none;
   }
 }

--- a/src/components/SponsorsRail.module.css
+++ b/src/components/SponsorsRail.module.css
@@ -18,29 +18,7 @@
 }
 
 .animatedViewport {
-  position: relative;
   overflow-y: hidden;
-}
-
-.animatedViewport::before,
-.animatedViewport::after {
-  content: '';
-  position: absolute;
-  z-index: 1;
-  right: 0;
-  left: 0;
-  height: 1rem;
-  pointer-events: none;
-}
-
-.animatedViewport::before {
-  top: 0;
-  background: linear-gradient(to bottom, var(--ui-color-page), transparent);
-}
-
-.animatedViewport::after {
-  bottom: 0;
-  background: linear-gradient(to top, var(--ui-color-page), transparent);
 }
 
 .viewport::-webkit-scrollbar {

--- a/src/components/SponsorsRail.module.css
+++ b/src/components/SponsorsRail.module.css
@@ -20,6 +20,8 @@
 .animatedViewport {
   overflow-y: hidden;
   --rail-edge-fade-size: 1.25rem;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-size: 100% 100%;
   -webkit-mask-image: linear-gradient(
     to bottom,
     transparent,
@@ -27,6 +29,8 @@
     #000 calc(100% - var(--rail-edge-fade-size)),
     transparent
   );
+  mask-repeat: no-repeat;
+  mask-size: 100% 100%;
   mask-image: linear-gradient(
     to bottom,
     transparent,

--- a/src/components/SponsorsRail.module.css
+++ b/src/components/SponsorsRail.module.css
@@ -46,6 +46,10 @@
   min-width: 0;
 }
 
+.animatedViewport .stack {
+  will-change: transform;
+}
+
 .segment {
   display: grid;
   grid-auto-rows: min-content;

--- a/src/components/__tests__/SponsorsRail.test.jsx
+++ b/src/components/__tests__/SponsorsRail.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, vi } from 'vitest';
 import SponsorsRail from '../SponsorsRail';
 
@@ -89,5 +89,41 @@ describe('SponsorsRail', () => {
     render(<SponsorsRail sponsors={sponsors} loopItemTarget={3} />);
 
     expect(window.requestAnimationFrame).not.toHaveBeenCalled();
+  });
+
+  test('resets the rail to its scroll origin when reduced motion is enabled', () => {
+    let mediaQueryListener;
+    const mediaQuery = {
+      matches: false,
+      addEventListener: vi.fn((_event, listener) => {
+        mediaQueryListener = listener;
+      }),
+      removeEventListener: vi.fn(),
+    };
+    const frames = new Map();
+    let frameId = 0;
+    const requestAnimationFrame = vi.fn((callback) => {
+      frameId += 1;
+      frames.set(frameId, callback);
+      return frameId;
+    });
+
+    vi.stubGlobal('requestAnimationFrame', requestAnimationFrame);
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+    vi.stubGlobal('matchMedia', () => mediaQuery);
+
+    const { container } = render(<SponsorsRail sponsors={sponsors} loopItemTarget={3} />);
+    const track = container.querySelector('[class*="stack"]');
+
+    frames.get(1)(0);
+    frames.get(2)(100);
+    expect(track).toHaveStyle('transform: translate3d(0, -1.1px, 0)');
+
+    mediaQuery.matches = true;
+    act(() => mediaQueryListener());
+
+    expect(window.cancelAnimationFrame).toHaveBeenCalledWith(3);
+    expect(track).toHaveStyle('transform:');
+    expect(window.requestAnimationFrame).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/components/__tests__/SponsorsRail.test.jsx
+++ b/src/components/__tests__/SponsorsRail.test.jsx
@@ -1,5 +1,10 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, vi } from 'vitest';
 import SponsorsRail from '../SponsorsRail';
+
+vi.mock('../../hooks/useMeasuredLoop', () => ({
+  default: () => ({ copies: 3, cycleExtent: 100 }),
+}));
 
 const sponsors = [
   { imageDataUrl: 'data:image/png;base64,one', name: 'Primeiro', link: 'https://example.com/one' },
@@ -7,6 +12,10 @@ const sponsors = [
 ];
 
 describe('SponsorsRail', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   test('fills a shorter visual rail to the shared loop capacity without duplicating accessible sponsors', () => {
     const { container } = render(<SponsorsRail sponsors={sponsors} loopItemTarget={3} />);
 
@@ -41,5 +50,44 @@ describe('SponsorsRail', () => {
 
     expect(container.querySelectorAll('a, div[class*="slot"]')).toHaveLength(1);
     expect(screen.getAllByRole('img')).toHaveLength(1);
+  });
+
+  test('stops animation frames while the rail is paused and resumes them afterwards', () => {
+    const requestAnimationFrame = vi.fn(() => 1);
+    const cancelAnimationFrame = vi.fn();
+    const matchMedia = vi.fn(() => ({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }));
+
+    vi.stubGlobal('requestAnimationFrame', requestAnimationFrame);
+    vi.stubGlobal('cancelAnimationFrame', cancelAnimationFrame);
+    vi.stubGlobal('matchMedia', matchMedia);
+
+    const { container } = render(<SponsorsRail sponsors={sponsors} loopItemTarget={3} />);
+    const rail = container.querySelector('aside');
+
+    expect(requestAnimationFrame).toHaveBeenCalledTimes(1);
+
+    fireEvent.mouseEnter(rail);
+    expect(cancelAnimationFrame).toHaveBeenCalledWith(1);
+    expect(requestAnimationFrame).toHaveBeenCalledTimes(1);
+
+    fireEvent.mouseLeave(rail, { relatedTarget: document.body });
+    expect(requestAnimationFrame).toHaveBeenCalledTimes(2);
+  });
+
+  test('does not schedule animation frames when reduced motion is preferred', () => {
+    vi.stubGlobal('requestAnimationFrame', vi.fn());
+    vi.stubGlobal('matchMedia', () => ({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }));
+
+    render(<SponsorsRail sponsors={sponsors} loopItemTarget={3} />);
+
+    expect(window.requestAnimationFrame).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/useInteractiveLoop.js
+++ b/src/hooks/useInteractiveLoop.js
@@ -30,6 +30,7 @@ export default function useInteractiveLoop({
   trackRef,
 }) {
   const animationRef = useRef(null);
+  const animationProgressRef = useRef(0);
   const dragRef = useRef(null);
   const resumeTimeoutRef = useRef(0);
   const suppressClickRef = useRef(false);
@@ -61,18 +62,23 @@ export default function useInteractiveLoop({
       axis === 'x'
         ? `translate3d(${-cycleExtent}px, 0, 0)`
         : `translate3d(0, ${-cycleExtent}px, 0)`;
+    const animationDuration = durationSeconds * 1000;
     const animation = track.animate(
       [{ transform: 'translate3d(0, 0, 0)' }, { transform: translate }],
       {
-        duration: durationSeconds * 1000,
+        duration: animationDuration,
         easing: 'linear',
         iterations: Infinity,
       }
     );
+    animation.currentTime = animationProgressRef.current * animationDuration;
     animationRef.current = animation;
 
     return () => {
       window.clearTimeout(resumeTimeoutRef.current);
+      const currentTime = Number(animation.currentTime ?? 0);
+      animationProgressRef.current =
+        normalizeLoopTime(currentTime, animationDuration) / animationDuration;
       animation.cancel();
       if (animationRef.current === animation) {
         animationRef.current = null;

--- a/src/pages/Leaderboard.module.css
+++ b/src/pages/Leaderboard.module.css
@@ -127,25 +127,6 @@
   flex: 0 1 auto;
 }
 
-.totalBadge {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--ui-space-xs);
-  padding: 0.45rem 0.75rem;
-  border-radius: var(--ui-radius-sm);
-  background: rgba(34, 197, 94, 0.04);
-  border: 1px solid rgba(34, 197, 94, 0.1);
-  box-shadow: none;
-  max-width: 15rem;
-  line-height: 1;
-}
-
-.totalValue {
-  white-space: nowrap;
-  font-size: clamp(1rem, 0.75vw + 0.55rem, 1.28rem);
-  line-height: 1;
-}
-
 .feedback {
   padding: var(--ui-space-lg);
   border-radius: var(--ui-radius-lg);
@@ -168,6 +149,7 @@
     --leaderboard-grid-template,
     clamp(3.25rem, 8vw, 4.25rem) minmax(0, 1fr) clamp(5rem, 12vw, 7rem)
   );
+  column-gap: var(--leaderboard-column-gap, var(--ui-space-md));
   align-items: center;
   min-height: var(--leaderboard-row-height, 5rem);
   padding: var(--ui-space-sm) var(--ui-space-md);
@@ -202,13 +184,14 @@
 }
 
 .skeletonValue {
-  justify-self: end;
-  width: 3.25rem;
-  height: 1.25rem;
+  justify-self: stretch;
+  width: auto;
+  height: 0.75rem;
 }
 
 .tableSurface {
-  --leaderboard-grid-template: clamp(3.25rem, 8vw, 4.25rem) minmax(0, 1fr) clamp(5rem, 12vw, 7rem);
+  --leaderboard-grid-template: clamp(3.25rem, 8vw, 4.25rem) minmax(9rem, 0.55fr) minmax(0, 1.45fr);
+  --leaderboard-column-gap: var(--ui-space-md);
   --leaderboard-row-height: 5rem;
   --leaderboard-row-gap: 0.75rem;
   display: flex;
@@ -246,6 +229,7 @@
 .headerRow {
   display: grid;
   grid-template-columns: var(--leaderboard-grid-template);
+  column-gap: var(--leaderboard-column-gap, var(--ui-space-md));
   align-items: center;
   padding: var(--ui-space-xs) var(--ui-space-md);
   border-radius: var(--ui-radius-sm);
@@ -359,6 +343,7 @@
 
 @media (min-width: 75rem) and (max-width: 89.9375rem) {
   .tableSurface {
+    --leaderboard-grid-template: 4rem minmax(8.5rem, 0.5fr) minmax(0, 1.5fr);
     --leaderboard-row-height: 4rem;
     --leaderboard-row-gap: 0.5rem;
   }
@@ -376,9 +361,13 @@
 }
 
 .displayPage .tableSurface {
-  --leaderboard-grid-template: 4.5rem minmax(0, 1fr) 8rem;
+  --leaderboard-grid-template: 4.5rem minmax(12rem, 0.58fr) minmax(18rem, 1.42fr);
   --leaderboard-row-height: 3rem;
   --leaderboard-row-gap: 0.3125rem;
+}
+
+.displayPage .skeletonValue {
+  height: 0.625rem;
 }
 
 .displayPage .scrollRegion {
@@ -421,11 +410,6 @@
 
 .displayPage .tableCount {
   font-size: 1rem;
-}
-
-.displayPage .totalBadge {
-  gap: var(--ui-space-sm);
-  padding: 0.5rem 0.875rem;
 }
 
 @media (max-width: 48rem) {
@@ -473,15 +457,20 @@
     gap: var(--ui-space-xs);
   }
 
-  .totalBadge {
-    width: auto;
-    min-width: 0;
-  }
-
   .tableSurface {
-    --leaderboard-grid-template: 2.75rem minmax(0, 1fr) minmax(4.25rem, 4.75rem);
+    --leaderboard-grid-template: 2.5rem minmax(0, 1fr) auto;
+    --leaderboard-column-gap: var(--ui-space-sm);
     --leaderboard-row-height: 4rem;
     --leaderboard-row-gap: 0.4375rem;
+  }
+
+  .headerRow {
+    padding-left: var(--ui-space-sm);
+    padding-right: var(--ui-space-sm);
+  }
+
+  .headerCell:last-child {
+    justify-content: flex-end;
   }
 
   .heroStatCard {

--- a/src/pages/Leaderboard.module.css
+++ b/src/pages/Leaderboard.module.css
@@ -350,8 +350,8 @@
 
   .tableSurface {
     --leaderboard-grid-template: 4rem minmax(8.5rem, 0.5fr) minmax(0, 1.5fr);
-    --leaderboard-row-height: 3rem;
-    --leaderboard-row-gap: 0.25rem;
+    --leaderboard-row-height: 2.625rem;
+    --leaderboard-row-gap: 0.1875rem;
   }
 }
 

--- a/src/pages/Leaderboard.module.css
+++ b/src/pages/Leaderboard.module.css
@@ -112,6 +112,11 @@
 .tableHeaderMeta {
   gap: var(--ui-space-sm);
   flex-wrap: wrap;
+  min-width: 0;
+}
+
+.tableHeaderMeta > :first-child {
+  min-width: 0;
 }
 
 .tableCount {
@@ -126,6 +131,7 @@
   flex-wrap: wrap;
   justify-content: flex-end;
   flex: 0 1 auto;
+  min-width: 0;
 }
 
 .feedback {
@@ -313,7 +319,10 @@
 
 @media (min-width: 75rem) {
   .layout {
-    grid-template-columns: minmax(0, 15rem) minmax(0, 1fr) minmax(0, 15rem);
+    grid-template-columns: minmax(11rem, clamp(11rem, 18vw, 15rem)) minmax(0, 1fr) minmax(
+        11rem,
+        clamp(11rem, 18vw, 15rem)
+      );
     grid-template-areas: 'left content right';
     align-items: start;
   }
@@ -331,7 +340,18 @@
   }
 
   .tableHeaderMeta {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
     flex-wrap: nowrap;
+  }
+
+  .tableHeaderMeta h2 {
+    min-width: 0;
+  }
+
+  .tableBadges {
+    margin-right: var(--ui-space-xs);
   }
 }
 
@@ -349,9 +369,32 @@
   }
 
   .tableSurface {
-    --leaderboard-grid-template: 4rem minmax(8.5rem, 0.5fr) minmax(0, 1.5fr);
-    --leaderboard-row-height: 2.5rem;
+    --leaderboard-grid-template: clamp(3.25rem, 5vw, 4rem) minmax(clamp(8rem, 20vw, 12rem), 0.5fr)
+      minmax(0, 1.5fr);
+    --leaderboard-row-height: 2.25rem;
     --leaderboard-row-gap: 0.125rem;
+  }
+
+  .tableHeaderMeta {
+    gap: var(--ui-space-sm);
+  }
+
+  .tableHeaderMeta h2 {
+    font-size: clamp(1.75rem, 2.65vw, 2.25rem);
+    line-height: 1.05;
+  }
+
+  .skeletonRank {
+    width: 1.875rem;
+    height: 1.875rem;
+  }
+
+  .skeletonName {
+    height: 1rem;
+  }
+
+  .skeletonValue {
+    height: 0.625rem;
   }
 }
 
@@ -393,7 +436,8 @@
 }
 
 .displayPage .tableSurface {
-  --leaderboard-grid-template: 4.5rem minmax(12rem, 0.58fr) minmax(18rem, 1.42fr);
+  --leaderboard-grid-template: clamp(3.75rem, 4vw, 4.5rem) minmax(clamp(10rem, 16vw, 15rem), 0.58fr)
+    minmax(18rem, 1.42fr);
   --leaderboard-row-height: 3rem;
   --leaderboard-row-gap: 0.3125rem;
 }
@@ -524,6 +568,9 @@
 
 @media (min-width: 90rem) {
   .displayPage .layout {
-    grid-template-columns: minmax(0, 13.75rem) minmax(0, 1fr) minmax(0, 13.75rem);
+    grid-template-columns: minmax(11rem, clamp(11rem, 14vw, 13.75rem)) minmax(0, 1fr) minmax(
+        11rem,
+        clamp(11rem, 14vw, 13.75rem)
+      );
   }
 }

--- a/src/pages/Leaderboard.module.css
+++ b/src/pages/Leaderboard.module.css
@@ -14,6 +14,7 @@
 }
 
 .displayPage {
+  height: calc(100dvh - (var(--ui-space-md) * 2));
   min-height: calc(100dvh - (var(--ui-space-md) * 2));
 }
 
@@ -350,8 +351,24 @@
 }
 
 .displayPage .layout {
-  min-height: calc(100dvh - (var(--ui-space-md) * 2));
+  height: 100%;
+  min-height: 0;
   gap: var(--ui-space-lg);
+  align-items: stretch;
+}
+
+.displayPage .content,
+.displayPage .content > section,
+.displayPage .tableCard,
+.displayPage .tableSurface,
+.displayPage .scrollRegion {
+  min-height: 0;
+}
+
+.displayPage .content > section,
+.displayPage .tableCard,
+.displayPage .tableSurface {
+  flex: 1 1 auto;
 }
 
 .displayPage .tableCard {
@@ -371,8 +388,9 @@
 }
 
 .displayPage .scrollRegion {
-  height: min(54rem, calc(100dvh - 13rem));
-  max-height: calc(100dvh - 10rem);
+  flex: 1 1 auto;
+  height: auto;
+  max-height: none;
   background: transparent;
   overflow-y: hidden;
   scrollbar-width: none;

--- a/src/pages/Leaderboard.module.css
+++ b/src/pages/Leaderboard.module.css
@@ -546,9 +546,8 @@
 
   .headerRow {
     grid-template-columns: 2.5rem minmax(0, 1fr);
-    grid-template-rows: min-content min-content;
+    grid-template-rows: min-content;
     align-content: center;
-    row-gap: 0.4rem;
     padding-left: var(--ui-space-sm);
     padding-right: var(--ui-space-sm);
   }
@@ -558,20 +557,13 @@
     justify-content: center;
   }
 
-  .headerCell:nth-child(2),
-  .headerCell:last-child {
-    grid-column: 2;
-  }
-
   .headerCell:nth-child(2) {
+    grid-column: 2;
     grid-row: 1;
-    align-self: end;
   }
 
   .headerCell:last-child {
-    grid-row: 2;
-    align-self: start;
-    justify-content: flex-start;
+    display: none;
   }
 
   .heroStatCard {

--- a/src/pages/Leaderboard.module.css
+++ b/src/pages/Leaderboard.module.css
@@ -545,12 +545,33 @@
   }
 
   .headerRow {
+    grid-template-columns: 2.5rem minmax(0, 1fr);
+    grid-template-rows: min-content min-content;
+    align-content: center;
+    row-gap: 0.4rem;
     padding-left: var(--ui-space-sm);
     padding-right: var(--ui-space-sm);
   }
 
+  .headerCell:first-child {
+    grid-row: 1 / -1;
+    justify-content: center;
+  }
+
+  .headerCell:nth-child(2),
   .headerCell:last-child {
-    justify-content: flex-end;
+    grid-column: 2;
+  }
+
+  .headerCell:nth-child(2) {
+    grid-row: 1;
+    align-self: end;
+  }
+
+  .headerCell:last-child {
+    grid-row: 2;
+    align-self: start;
+    justify-content: flex-start;
   }
 
   .heroStatCard {

--- a/src/pages/Leaderboard.module.css
+++ b/src/pages/Leaderboard.module.css
@@ -357,6 +357,10 @@
   align-items: stretch;
 }
 
+.displayPage .railSlot > aside {
+  top: 0;
+}
+
 .displayPage .content,
 .displayPage .content > section,
 .displayPage .tableCard,

--- a/src/pages/Leaderboard.module.css
+++ b/src/pages/Leaderboard.module.css
@@ -361,6 +361,24 @@
   top: 0;
 }
 
+.displayPage .railSlot > aside > div {
+  position: relative;
+  height: calc(100dvh - (var(--ui-space-md) * 2));
+  max-height: none;
+}
+
+.displayPage .railSlot > aside > div::after {
+  content: '';
+  position: absolute;
+  z-index: 1;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 1rem;
+  pointer-events: none;
+  background: linear-gradient(to top, var(--ui-color-page), transparent);
+}
+
 .displayPage .content,
 .displayPage .content > section,
 .displayPage .tableCard,

--- a/src/pages/Leaderboard.module.css
+++ b/src/pages/Leaderboard.module.css
@@ -377,7 +377,7 @@
   .tableSurface {
     --leaderboard-grid-template: clamp(3.25rem, 5vw, 4rem) minmax(clamp(8rem, 20vw, 12rem), 0.5fr)
       minmax(0, 1.5fr);
-    --leaderboard-row-height: 2.25rem;
+    --leaderboard-row-height: 2.75rem;
     --leaderboard-row-gap: 0.125rem;
   }
 
@@ -391,8 +391,8 @@
   }
 
   .skeletonRank {
-    width: 1.875rem;
-    height: 1.875rem;
+    width: 2.125rem;
+    height: 2.125rem;
   }
 
   .skeletonName {

--- a/src/pages/Leaderboard.module.css
+++ b/src/pages/Leaderboard.module.css
@@ -110,6 +110,7 @@
 }
 
 .tableHeaderMeta {
+  --leaderboard-header-end-inset: var(--ui-space-xs);
   gap: var(--ui-space-sm);
   flex-wrap: wrap;
   min-width: 0;
@@ -192,7 +193,6 @@
 
 .skeletonValue {
   justify-self: stretch;
-  width: auto;
   height: 0.75rem;
 }
 
@@ -319,10 +319,7 @@
 
 @media (min-width: 75rem) {
   .layout {
-    grid-template-columns: minmax(11rem, clamp(11rem, 18vw, 15rem)) minmax(0, 1fr) minmax(
-        11rem,
-        clamp(11rem, 18vw, 15rem)
-      );
+    grid-template-columns: clamp(11rem, 18vw, 15rem) minmax(0, 1fr) clamp(11rem, 18vw, 15rem);
     grid-template-areas: 'left content right';
     align-items: start;
   }
@@ -351,12 +348,12 @@
   }
 
   .tableBadges {
-    margin-right: var(--ui-space-xs);
+    margin-right: var(--leaderboard-header-end-inset);
   }
 
   @supports (font: -apple-system-body) {
-    .tableBadges {
-      margin-right: var(--ui-space-2xs);
+    .tableHeaderMeta {
+      --leaderboard-header-end-inset: var(--ui-space-2xs);
     }
   }
 }
@@ -379,10 +376,6 @@
       minmax(0, 1.5fr);
     --leaderboard-row-height: 2.75rem;
     --leaderboard-row-gap: 0.125rem;
-  }
-
-  .tableHeaderMeta {
-    gap: var(--ui-space-sm);
   }
 
   .tableHeaderMeta h2 {
@@ -574,9 +567,6 @@
 
 @media (min-width: 90rem) {
   .displayPage .layout {
-    grid-template-columns: minmax(11rem, clamp(11rem, 14vw, 13.75rem)) minmax(0, 1fr) minmax(
-        11rem,
-        clamp(11rem, 14vw, 13.75rem)
-      );
+    grid-template-columns: clamp(11rem, 14vw, 13.75rem) minmax(0, 1fr) clamp(11rem, 14vw, 13.75rem);
   }
 }

--- a/src/pages/Leaderboard.module.css
+++ b/src/pages/Leaderboard.module.css
@@ -353,6 +353,12 @@
   .tableBadges {
     margin-right: var(--ui-space-xs);
   }
+
+  @supports (font: -apple-system-body) {
+    .tableBadges {
+      margin-right: var(--ui-space-2xs);
+    }
+  }
 }
 
 @media (max-width: 74.9375rem) {

--- a/src/pages/Leaderboard.module.css
+++ b/src/pages/Leaderboard.module.css
@@ -367,18 +367,6 @@
   max-height: none;
 }
 
-.displayPage .railSlot > aside > div::after {
-  content: '';
-  position: absolute;
-  z-index: 1;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  height: 1rem;
-  pointer-events: none;
-  background: linear-gradient(to top, var(--ui-color-page), transparent);
-}
-
 .displayPage .content,
 .displayPage .content > section,
 .displayPage .tableCard,

--- a/src/pages/Leaderboard.module.css
+++ b/src/pages/Leaderboard.module.css
@@ -350,8 +350,8 @@
 
   .tableSurface {
     --leaderboard-grid-template: 4rem minmax(8.5rem, 0.5fr) minmax(0, 1.5fr);
-    --leaderboard-row-height: 2.625rem;
-    --leaderboard-row-gap: 0.1875rem;
+    --leaderboard-row-height: 2.5rem;
+    --leaderboard-row-gap: 0.125rem;
   }
 }
 

--- a/src/pages/Leaderboard.module.css
+++ b/src/pages/Leaderboard.module.css
@@ -343,10 +343,15 @@
 }
 
 @media (min-width: 75rem) and (max-width: 89.9375rem) {
+  .page:not(.displayPage) .railSlot > aside {
+    top: 3rem;
+    margin-top: calc(-1 * var(--ui-space-lg));
+  }
+
   .tableSurface {
     --leaderboard-grid-template: 4rem minmax(8.5rem, 0.5fr) minmax(0, 1.5fr);
-    --leaderboard-row-height: 4rem;
-    --leaderboard-row-gap: 0.5rem;
+    --leaderboard-row-height: 3.5rem;
+    --leaderboard-row-gap: 0.375rem;
   }
 }
 

--- a/src/pages/Leaderboard.module.css
+++ b/src/pages/Leaderboard.module.css
@@ -350,8 +350,8 @@
 
   .tableSurface {
     --leaderboard-grid-template: 4rem minmax(8.5rem, 0.5fr) minmax(0, 1.5fr);
-    --leaderboard-row-height: 3.5rem;
-    --leaderboard-row-gap: 0.375rem;
+    --leaderboard-row-height: 3rem;
+    --leaderboard-row-gap: 0.25rem;
   }
 }
 
@@ -422,6 +422,10 @@
   z-index: 1;
   padding-bottom: var(--leaderboard-row-gap, 0.3125rem);
   background: var(--ui-color-surface-muted);
+}
+
+.displayPage .fullList {
+  will-change: transform;
 }
 
 .displayPage .introSection {

--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -10,7 +10,7 @@ import styles from './Leaderboard.module.css';
 import { LeaderboardRow } from '../components/LeaderboardRow';
 
 const DEFAULT_ROW_METRICS = { height: 80, gap: 12 };
-const LAPTOP_ROW_METRICS = { height: 48, gap: 4 };
+const LAPTOP_ROW_METRICS = { height: 42, gap: 3 };
 const VIRTUALIZE_THRESHOLD = 50;
 const VISIBLE_WINDOW = 18;
 const BUFFER = 6;

--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -10,7 +10,7 @@ import styles from './Leaderboard.module.css';
 import { LeaderboardRow } from '../components/LeaderboardRow';
 
 const DEFAULT_ROW_METRICS = { height: 80, gap: 12 };
-const LAPTOP_ROW_METRICS = { height: 42, gap: 3 };
+const LAPTOP_ROW_METRICS = { height: 40, gap: 2 };
 const VIRTUALIZE_THRESHOLD = 50;
 const VISIBLE_WINDOW = 18;
 const BUFFER = 6;

--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -10,7 +10,7 @@ import styles from './Leaderboard.module.css';
 import { LeaderboardRow } from '../components/LeaderboardRow';
 
 const DEFAULT_ROW_METRICS = { height: 80, gap: 12 };
-const LAPTOP_ROW_METRICS = { height: 36, gap: 2 };
+const LAPTOP_ROW_METRICS = { height: 44, gap: 2 };
 const VIRTUALIZE_THRESHOLD = 50;
 const VISIBLE_WINDOW = 18;
 const BUFFER = 6;

--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -10,7 +10,7 @@ import styles from './Leaderboard.module.css';
 import { LeaderboardRow } from '../components/LeaderboardRow';
 
 const DEFAULT_ROW_METRICS = { height: 80, gap: 12 };
-const LAPTOP_ROW_METRICS = { height: 64, gap: 8 };
+const LAPTOP_ROW_METRICS = { height: 56, gap: 6 };
 const VIRTUALIZE_THRESHOLD = 50;
 const VISIBLE_WINDOW = 18;
 const BUFFER = 6;

--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -347,7 +347,7 @@ export default function Leaderboard({ displayMode = false }: LeaderboardProps = 
                 sponsors={sponsorColumns[0]}
                 side="left"
                 loopItemTarget={sponsorLoopItemTarget}
-                autoScroll={canAnimateSponsorRails}
+                autoScroll={displayMode && canAnimateSponsorRails}
               />
             )}
           </div>
@@ -522,7 +522,7 @@ export default function Leaderboard({ displayMode = false }: LeaderboardProps = 
                 sponsors={sponsorColumns[1]}
                 side="right"
                 loopItemTarget={sponsorLoopItemTarget}
-                autoScroll={canAnimateSponsorRails}
+                autoScroll={displayMode && canAnimateSponsorRails}
               />
             )}
           </div>

--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -10,7 +10,7 @@ import styles from './Leaderboard.module.css';
 import { LeaderboardRow } from '../components/LeaderboardRow';
 
 const DEFAULT_ROW_METRICS = { height: 80, gap: 12 };
-const LAPTOP_ROW_METRICS = { height: 40, gap: 2 };
+const LAPTOP_ROW_METRICS = { height: 36, gap: 2 };
 const VIRTUALIZE_THRESHOLD = 50;
 const VISIBLE_WINDOW = 18;
 const BUFFER = 6;

--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -347,7 +347,7 @@ export default function Leaderboard({ displayMode = false }: LeaderboardProps = 
                 sponsors={sponsorColumns[0]}
                 side="left"
                 loopItemTarget={sponsorLoopItemTarget}
-                autoScroll={displayMode && canAnimateSponsorRails}
+                autoScroll={canAnimateSponsorRails}
               />
             )}
           </div>
@@ -522,7 +522,7 @@ export default function Leaderboard({ displayMode = false }: LeaderboardProps = 
                 sponsors={sponsorColumns[1]}
                 side="right"
                 loopItemTarget={sponsorLoopItemTarget}
-                autoScroll={displayMode && canAnimateSponsorRails}
+                autoScroll={canAnimateSponsorRails}
               />
             )}
           </div>

--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -10,7 +10,7 @@ import styles from './Leaderboard.module.css';
 import { LeaderboardRow } from '../components/LeaderboardRow';
 
 const DEFAULT_ROW_METRICS = { height: 80, gap: 12 };
-const LAPTOP_ROW_METRICS = { height: 56, gap: 6 };
+const LAPTOP_ROW_METRICS = { height: 48, gap: 4 };
 const VIRTUALIZE_THRESHOLD = 50;
 const VISIBLE_WINDOW = 18;
 const BUFFER = 6;
@@ -106,6 +106,7 @@ export default function Leaderboard({ displayMode = false }: LeaderboardProps = 
   const [isCompactViewport, setIsCompactViewport] = useState(false);
   const [isLaptopViewport, setIsLaptopViewport] = useState(false);
   const scrollRef = useRef<HTMLDivElement | null>(null);
+  const displayScrollListRef = useRef<HTMLDivElement | null>(null);
   const [scrollTop, setScrollTop] = useState(0);
 
   useEffect(() => {
@@ -215,47 +216,53 @@ export default function Leaderboard({ displayMode = false }: LeaderboardProps = 
     }
 
     const container = scrollRef.current;
-    if (!container) {
+    const list = displayScrollListRef.current;
+    if (!container || !list) {
       return;
     }
 
     const reduceMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches ?? false;
-    if (reduceMotion) {
+    if (reduceMotion || typeof list.animate !== 'function') {
       return;
     }
 
-    let frameId = 0;
     let pauseTimeoutId = 0;
     let direction: 1 | -1 = 1;
+    let currentOffset = 0;
+    let activeAnimation: Animation | null = null;
 
     const getMaxScrollTop = () => Math.max(0, container.scrollHeight - container.clientHeight);
+    const applyOffset = (offset: number) => {
+      list.style.transform = `translate3d(0, -${offset}px, 0)`;
+    };
 
-    const animateTo = (targetScrollTop: number) => {
-      window.cancelAnimationFrame(frameId);
-      const startScrollTop = container.scrollTop;
-      const distance = Math.abs(targetScrollTop - startScrollTop);
+    const animateTo = (targetOffset: number) => {
+      activeAnimation?.cancel();
+      const startOffset = currentOffset;
+      const distance = Math.abs(targetOffset - startOffset);
       const duration = Math.max(2600, (distance / DISPLAY_SCROLL_PX_PER_SECOND) * 1000);
-      let startTime = 0;
 
-      const step = (timestamp: number) => {
-        if (!startTime) {
-          startTime = timestamp;
-        }
+      const animation = list.animate(
+        [
+          { transform: `translate3d(0, -${startOffset}px, 0)` },
+          { transform: `translate3d(0, -${targetOffset}px, 0)` },
+        ],
+        { duration, easing: 'linear', fill: 'forwards' }
+      );
+      activeAnimation = animation;
 
-        const progress = Math.min(1, (timestamp - startTime) / duration);
-        container.scrollTop = startScrollTop + (targetScrollTop - startScrollTop) * progress;
-
-        if (progress < 1) {
-          frameId = window.requestAnimationFrame(step);
+      animation.onfinish = () => {
+        if (activeAnimation !== animation) {
           return;
         }
 
-        container.scrollTop = targetScrollTop;
+        currentOffset = targetOffset;
+        applyOffset(currentOffset);
+        animation.cancel();
+        activeAnimation = null;
         direction = direction === 1 ? -1 : 1;
         pauseTimeoutId = window.setTimeout(scheduleNextScroll, DISPLAY_SCROLL_PAUSE_MS);
       };
-
-      frameId = window.requestAnimationFrame(step);
     };
 
     const scheduleNextScroll = () => {
@@ -268,14 +275,13 @@ export default function Leaderboard({ displayMode = false }: LeaderboardProps = 
       animateTo(direction === 1 ? maxScrollTop : 0);
     };
 
-    container.scrollTop = 0;
-    frameId = window.requestAnimationFrame(() => {
-      pauseTimeoutId = window.setTimeout(scheduleNextScroll, DISPLAY_SCROLL_PAUSE_MS);
-    });
+    applyOffset(0);
+    pauseTimeoutId = window.setTimeout(scheduleNextScroll, DISPLAY_SCROLL_PAUSE_MS);
 
     return () => {
-      window.cancelAnimationFrame(frameId);
+      activeAnimation?.cancel();
       window.clearTimeout(pauseTimeoutId);
+      list.style.transform = '';
     };
   }, [displayMode, teams.length]);
 
@@ -455,7 +461,11 @@ export default function Leaderboard({ displayMode = false }: LeaderboardProps = 
                               ))}
                             </div>
                             {displayScrollableTeams.length > 0 ? (
-                              <div className={styles.fullList} role="presentation">
+                              <div
+                                ref={displayScrollListRef}
+                                className={styles.fullList}
+                                role="presentation"
+                              >
                                 {displayScrollableTeams.map((team, index) => (
                                   <LeaderboardRow
                                     key={team.id}

--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -19,8 +19,6 @@ const DISPLAY_PINNED_ROWS = 5;
 const DISPLAY_SCROLL_PX_PER_SECOND = 30;
 const DISPLAY_SCROLL_PAUSE_MS = 2200;
 
-const numberFormatter = new Intl.NumberFormat('pt-PT');
-
 const skeletonRows = Array.from({ length: 8 }, (_, index) => index);
 
 type ServiceTeam = {
@@ -310,7 +308,6 @@ export default function Leaderboard({ displayMode = false }: LeaderboardProps = 
     [teams]
   );
 
-  const totalPingas = useMemo(() => teams.reduce((total, team) => total + team.pingas, 0), [teams]);
   const displayPinnedTeams = displayMode ? teams.slice(0, DISPLAY_PINNED_ROWS) : [];
   const displayScrollableTeams = displayMode ? teams.slice(DISPLAY_PINNED_ROWS) : [];
 
@@ -329,7 +326,7 @@ export default function Leaderboard({ displayMode = false }: LeaderboardProps = 
   const sponsorLoopItemTarget =
     canAnimateSponsorRails && largestSponsorRail === 3 ? 4 : largestSponsorRail || undefined;
 
-  const tableAriaLabel = 'Classificação geral das equipas por pingas acumuladas';
+  const tableAriaLabel = 'Classificação geral das equipas por pingas em escala relativa';
 
   return (
     <>
@@ -390,14 +387,6 @@ export default function Leaderboard({ displayMode = false }: LeaderboardProps = 
                         ? '1 equipa em prova'
                         : `${teams.length} equipas em prova`}
                     </Text>
-                    <div className={styles.totalBadge} aria-label="Total de pingas registadas">
-                      <Text as="span" variant="label" tone="muted">
-                        Total de Pingas
-                      </Text>
-                      <Text as="span" variant="heading" weight="bold" className={styles.totalValue}>
-                        {numberFormatter.format(totalPingas)}
-                      </Text>
-                    </div>
                   </div>
                 </Stack>
 
@@ -444,10 +433,7 @@ export default function Leaderboard({ displayMode = false }: LeaderboardProps = 
                           <span role="columnheader" className={styles.headerCell}>
                             Equipa
                           </span>
-                          <span
-                            role="columnheader"
-                            className={`${styles.headerCell} ${styles.headerCellEnd}`}
-                          >
+                          <span role="columnheader" className={styles.headerCell}>
                             Pingas
                           </span>
                         </div>
@@ -465,7 +451,6 @@ export default function Leaderboard({ displayMode = false }: LeaderboardProps = 
                                   pingas={team.pingas}
                                   maxPingas={maxPingas}
                                   ariaRowIndex={index + 2}
-                                  numberFormatter={numberFormatter}
                                 />
                               ))}
                             </div>
@@ -479,7 +464,6 @@ export default function Leaderboard({ displayMode = false }: LeaderboardProps = 
                                     pingas={team.pingas}
                                     maxPingas={maxPingas}
                                     ariaRowIndex={index + DISPLAY_PINNED_ROWS + 2}
-                                    numberFormatter={numberFormatter}
                                   />
                                 ))}
                               </div>
@@ -504,7 +488,6 @@ export default function Leaderboard({ displayMode = false }: LeaderboardProps = 
                                   pingas={team.pingas}
                                   maxPingas={maxPingas}
                                   ariaRowIndex={virtualState.startIndex + index + 2}
-                                  numberFormatter={numberFormatter}
                                 />
                               ))}
                             </div>
@@ -519,7 +502,6 @@ export default function Leaderboard({ displayMode = false }: LeaderboardProps = 
                                 pingas={team.pingas}
                                 maxPingas={maxPingas}
                                 ariaRowIndex={index + 2}
-                                numberFormatter={numberFormatter}
                               />
                             ))}
                           </div>

--- a/src/pages/__tests__/LeaderboardPage.test.tsx
+++ b/src/pages/__tests__/LeaderboardPage.test.tsx
@@ -79,8 +79,8 @@ describe('Leaderboard page', () => {
 
   it('keeps virtual row measurements in sync with compact laptop rows', () => {
     expect(getVirtualRowMetrics(false)).toEqual({ height: 80, gap: 12 });
-    expect(getVirtualRowMetrics(true)).toEqual({ height: 48, gap: 4 });
-    expect(getRowsetHeight(120, 48, 4)).toBe(6236);
+    expect(getVirtualRowMetrics(true)).toEqual({ height: 42, gap: 3 });
+    expect(getRowsetHeight(120, 42, 3)).toBe(5397);
   });
 
   it('orders teams by pingas (desc) and then name (asc)', async () => {

--- a/src/pages/__tests__/LeaderboardPage.test.tsx
+++ b/src/pages/__tests__/LeaderboardPage.test.tsx
@@ -79,8 +79,8 @@ describe('Leaderboard page', () => {
 
   it('keeps virtual row measurements in sync with compact laptop rows', () => {
     expect(getVirtualRowMetrics(false)).toEqual({ height: 80, gap: 12 });
-    expect(getVirtualRowMetrics(true)).toEqual({ height: 64, gap: 8 });
-    expect(getRowsetHeight(120, 64, 8)).toBe(8632);
+    expect(getVirtualRowMetrics(true)).toEqual({ height: 56, gap: 6 });
+    expect(getRowsetHeight(120, 56, 6)).toBe(7434);
   });
 
   it('orders teams by pingas (desc) and then name (asc)', async () => {

--- a/src/pages/__tests__/LeaderboardPage.test.tsx
+++ b/src/pages/__tests__/LeaderboardPage.test.tsx
@@ -79,8 +79,8 @@ describe('Leaderboard page', () => {
 
   it('keeps virtual row measurements in sync with compact laptop rows', () => {
     expect(getVirtualRowMetrics(false)).toEqual({ height: 80, gap: 12 });
-    expect(getVirtualRowMetrics(true)).toEqual({ height: 40, gap: 2 });
-    expect(getRowsetHeight(120, 40, 2)).toBe(5038);
+    expect(getVirtualRowMetrics(true)).toEqual({ height: 36, gap: 2 });
+    expect(getRowsetHeight(120, 36, 2)).toBe(4558);
   });
 
   it('orders teams by pingas (desc) and then name (asc)', async () => {

--- a/src/pages/__tests__/LeaderboardPage.test.tsx
+++ b/src/pages/__tests__/LeaderboardPage.test.tsx
@@ -79,8 +79,8 @@ describe('Leaderboard page', () => {
 
   it('keeps virtual row measurements in sync with compact laptop rows', () => {
     expect(getVirtualRowMetrics(false)).toEqual({ height: 80, gap: 12 });
-    expect(getVirtualRowMetrics(true)).toEqual({ height: 56, gap: 6 });
-    expect(getRowsetHeight(120, 56, 6)).toBe(7434);
+    expect(getVirtualRowMetrics(true)).toEqual({ height: 48, gap: 4 });
+    expect(getRowsetHeight(120, 48, 4)).toBe(6236);
   });
 
   it('orders teams by pingas (desc) and then name (asc)', async () => {

--- a/src/pages/__tests__/LeaderboardPage.test.tsx
+++ b/src/pages/__tests__/LeaderboardPage.test.tsx
@@ -79,8 +79,8 @@ describe('Leaderboard page', () => {
 
   it('keeps virtual row measurements in sync with compact laptop rows', () => {
     expect(getVirtualRowMetrics(false)).toEqual({ height: 80, gap: 12 });
-    expect(getVirtualRowMetrics(true)).toEqual({ height: 36, gap: 2 });
-    expect(getRowsetHeight(120, 36, 2)).toBe(4558);
+    expect(getVirtualRowMetrics(true)).toEqual({ height: 44, gap: 2 });
+    expect(getRowsetHeight(120, 44, 2)).toBe(5518);
   });
 
   it('orders teams by pingas (desc) and then name (asc)', async () => {

--- a/src/pages/__tests__/LeaderboardPage.test.tsx
+++ b/src/pages/__tests__/LeaderboardPage.test.tsx
@@ -89,6 +89,7 @@ describe('Leaderboard page', () => {
         { id: 'b', name: 'Beta Rockets', pingas: 20 },
         { id: 'a', name: 'Alpha Squad', pingas: 20 },
         { id: 'c', name: 'Charlie Crew', pingas: 15 },
+        { id: 'd', name: 'Delta Crew', pingas: 1 },
       ]);
       return vi.fn();
     });
@@ -97,12 +98,60 @@ describe('Leaderboard page', () => {
 
     const rows = await screen.findAllByTestId('leaderboard-row');
 
-    expect(rows).toHaveLength(3);
+    expect(rows).toHaveLength(4);
     expect(rows[0]).toHaveTextContent('Alpha Squad');
     expect(rows[1]).toHaveTextContent('Beta Rockets');
     expect(rows[2]).toHaveTextContent('Charlie Crew');
-    expect(screen.getAllByTestId('score-beer-icon')).toHaveLength(3);
+    expect(rows[3]).toHaveTextContent('Delta Crew');
+    expect(rows[0]).toHaveStyle('--row-meter-start: #d97706');
+    expect(rows[1]).toHaveStyle('--row-meter-start: #64748b');
+    expect(rows[2]).toHaveStyle('--row-meter-start: #c2410c');
+    expect(rows[3]).toHaveStyle('--row-meter-start: #047857');
+    const meters = screen.getAllByRole('meter');
+    expect(meters).toHaveLength(4);
+    expect(meters.map((meter) => meter.getAttribute('aria-valuenow'))).toEqual([
+      '100',
+      '100',
+      '75',
+      '5',
+    ]);
+    expect(meters.every((meter) => meter.getAttribute('aria-valuemax') === '100')).toBe(true);
+    expect(meters.map((meter) => meter.getAttribute('aria-valuetext'))).toEqual([
+      'Alpha Squad está no valor de referência',
+      'Beta Rockets está no valor de referência',
+      'Charlie Crew está a 75% do valor da equipa líder',
+      'Delta Crew está a 5% do valor da equipa líder',
+    ]);
+    expect(screen.queryByTestId('score-beer-icon')).not.toBeInTheDocument();
+    expect(screen.queryByText('Total de Pingas')).not.toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Pingas' })).toBeInTheDocument();
+    expect(screen.queryByRole('columnheader', { name: 'Comparação' })).not.toBeInTheDocument();
     expect(screen.queryByText('pts')).not.toBeInTheDocument();
+    expect(rows[0]).not.toHaveTextContent(/\b20\b/);
+    expect(rows[2]).not.toHaveTextContent(/\b15\b/);
+    expect(rows[3]).not.toHaveTextContent(/\b1\b/);
+    expect(screen.queryByText('56')).not.toBeInTheDocument();
+  });
+
+  it('renders empty comparison meters without exposing a score', async () => {
+    observeLeaderboardMock.mockImplementation((callback) => {
+      callback([
+        { id: 'a', name: 'Alpha Squad', pingas: 0 },
+        { id: 'b', name: 'Beta Rockets', pingas: 0 },
+      ]);
+      return vi.fn();
+    });
+
+    renderLeaderboard();
+
+    const meters = await screen.findAllByRole('meter');
+    expect(meters).toHaveLength(2);
+    expect(meters.map((meter) => meter.getAttribute('aria-valuenow'))).toEqual(['0', '0']);
+    expect(meters.map((meter) => meter.getAttribute('aria-valuetext'))).toEqual([
+      'Alpha Squad ainda não tem valor registado',
+      'Beta Rockets ainda não tem valor registado',
+    ]);
+    expect(screen.queryByText('Total de Pingas')).not.toBeInTheDocument();
   });
 
   it('shows the empty state when there are no teams', async () => {

--- a/src/pages/__tests__/LeaderboardPage.test.tsx
+++ b/src/pages/__tests__/LeaderboardPage.test.tsx
@@ -79,8 +79,8 @@ describe('Leaderboard page', () => {
 
   it('keeps virtual row measurements in sync with compact laptop rows', () => {
     expect(getVirtualRowMetrics(false)).toEqual({ height: 80, gap: 12 });
-    expect(getVirtualRowMetrics(true)).toEqual({ height: 42, gap: 3 });
-    expect(getRowsetHeight(120, 42, 3)).toBe(5397);
+    expect(getVirtualRowMetrics(true)).toEqual({ height: 40, gap: 2 });
+    expect(getRowsetHeight(120, 40, 2)).toBe(5038);
   });
 
   it('orders teams by pingas (desc) and then name (asc)', async () => {

--- a/src/pages/__tests__/LeaderboardPage.test.tsx
+++ b/src/pages/__tests__/LeaderboardPage.test.tsx
@@ -154,6 +154,26 @@ describe('Leaderboard page', () => {
     expect(screen.queryByText('Total de Pingas')).not.toBeInTheDocument();
   });
 
+  it('does not announce a near-tied trailing team as the reference value', async () => {
+    observeLeaderboardMock.mockImplementation((callback) => {
+      callback([
+        { id: 'leader', name: 'Leader Squad', pingas: 201 },
+        { id: 'trailing', name: 'Trailing Squad', pingas: 200 },
+      ]);
+      return vi.fn();
+    });
+
+    renderLeaderboard();
+
+    const meters = await screen.findAllByRole('meter');
+
+    expect(meters.map((meter) => meter.getAttribute('aria-valuenow'))).toEqual(['100', '99']);
+    expect(meters.map((meter) => meter.getAttribute('aria-valuetext'))).toEqual([
+      'Leader Squad está no valor de referência',
+      'Trailing Squad está a 99% do valor da equipa líder',
+    ]);
+  });
+
   it('shows the empty state when there are no teams', async () => {
     observeLeaderboardMock.mockImplementation((callback) => {
       callback([]);


### PR DESCRIPTION
## Summary

- Replace public exact pinga values with normalized comparison bars.
- Preserve ranking, sanitization, virtualization, and both public leaderboard routes.
- Add gold, silver, and bronze podium bars, responsive mobile stacking, and wider laptop/TV bar columns.
- Remove the public aggregate total and beer score icons.

## Accessibility

- Meters expose normalized 0-100 values only.
- Portuguese accessible text describes the reference leader, relative percentage, or zero state.
- Raw scores are not rendered or exposed through meter attributes.

## Validation

- Focused leaderboard tests: passed
- Full test suite: 115 tests passed
- Firestore rules tests: 9 passed
- Lint: passed
- Typecheck: passed
- Production build: passed
- Browser validation: /leaderboard at mobile and laptop sizes, /display at 1920x1080, plus filled-bar visual fixtures and console checks

No services, schemas, Firestore rules, or dependencies changed.