### PR TITLE
docs: prepare tournament operations and release guidance

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,118 @@
+name: Deploy Production
+
+on:
+  push:
+    branches:
+      - production
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+
+    env:
+      VITE_FIREBASE_API_KEY: ${{ secrets.PRODUCTION_VITE_FIREBASE_API_KEY }}
+      VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.PRODUCTION_VITE_FIREBASE_AUTH_DOMAIN }}
+      VITE_FIREBASE_PROJECT_ID: ${{ secrets.PRODUCTION_VITE_FIREBASE_PROJECT_ID }}
+      VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.PRODUCTION_VITE_FIREBASE_STORAGE_BUCKET }}
+      VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.PRODUCTION_VITE_FIREBASE_MESSAGING_SENDER_ID }}
+      VITE_FIREBASE_APP_ID: ${{ secrets.PRODUCTION_VITE_FIREBASE_APP_ID }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Prepare Yarn 4
+        run: corepack prepare yarn@4.3.1 --activate
+
+      - name: Validate Firebase web config
+        run: |
+          missing=0
+          for key in \
+            VITE_FIREBASE_API_KEY \
+            VITE_FIREBASE_AUTH_DOMAIN \
+            VITE_FIREBASE_PROJECT_ID \
+            VITE_FIREBASE_STORAGE_BUCKET \
+            VITE_FIREBASE_MESSAGING_SENDER_ID \
+            VITE_FIREBASE_APP_ID
+          do
+            if [ -z "${!key:-}" ]; then
+              echo "::error::Missing production secret: $key" >&2
+              missing=1
+            fi
+          done
+
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
+      - name: Cache Yarn global cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.yarn/berry/cache
+          key: ${{ runner.os }}-yarn-berry-cache-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-berry-cache-
+
+      - name: Install dependencies
+        run: yarn install --immutable --mode=skip-build
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Unit tests
+        run: yarn test:ci
+
+      - name: Rules tests (Firestore emulator)
+        run: yarn test:rules
+
+      - name: Typecheck
+        run: yarn typecheck
+
+      - name: Build
+        run: yarn build
+
+      - name: Configure Firebase credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.PRODUCTION_FIREBASE_SERVICE_ACCOUNT }}
+        run: |
+          if [ -z "${FIREBASE_SERVICE_ACCOUNT}" ]; then
+            echo "::error::Missing production secret: FIREBASE_SERVICE_ACCOUNT" >&2
+            exit 1
+          fi
+
+          credentials_file="$RUNNER_TEMP/firebase-service-account.json"
+          echo "${FIREBASE_SERVICE_ACCOUNT}" > "$credentials_file"
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$credentials_file" >> "$GITHUB_ENV"
+
+      - name: Deploy Firestore rules and indexes
+        env:
+          FIREBASE_PROJECT_ID: ${{ secrets.PRODUCTION_FIREBASE_PROJECT_ID }}
+        run: |
+          if [ -z "${FIREBASE_PROJECT_ID}" ]; then
+            echo "::error::Missing production secret: FIREBASE_PROJECT_ID" >&2
+            exit 1
+          fi
+
+          ./node_modules/.bin/firebase deploy --only firestore --project "$FIREBASE_PROJECT_ID"
+
+      - name: Deploy hosting (production)
+        env:
+          FIREBASE_PROJECT_ID: ${{ secrets.PRODUCTION_FIREBASE_PROJECT_ID }}
+        run: ./node_modules/.bin/firebase deploy --only hosting --project "$FIREBASE_PROJECT_ID"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   deploy:
+    if: github.ref == 'refs/heads/production'
     runs-on: ubuntu-latest
     environment: production
 
@@ -115,4 +116,4 @@ jobs:
       - name: Deploy hosting (production)
         env:
           FIREBASE_PROJECT_ID: ${{ secrets.PRODUCTION_FIREBASE_PROJECT_ID }}
-        run: ./node_modules/.bin/firebase deploy --only hosting --project "$FIREBASE_PROJECT_ID"
+        run: ./node_modules/.bin/firebase deploy --only hosting:taca-da-pinga --project "$FIREBASE_PROJECT_ID"

--- a/README.md
+++ b/README.md
@@ -1,172 +1,61 @@
-# 🏆 Taça da Pinga
+# Taça da Pinga
 
-> A real-time tournament leaderboard for tracking drinks as **pingas** 🍺
+A real-time tournament leaderboard for tracking drinks as pingas.
 
-[![React](https://img.shields.io/badge/React-20232A?style=for-the-badge&logo=react&logoColor=61DAFB)](https://react.dev/)[![Firebase](https://img.shields.io/badge/Firebase-ffca28?style=for-the-badge&logo=firebase&logoColor=black)](https://firebase.google.com/)[![Recharts](https://img.shields.io/badge/Recharts-FF6384?style=for-the-badge&logo=chart.js&logoColor=white)](https://recharts.org/)[![CSS Modules](https://img.shields.io/badge/CSS%20Modules-000000?style=for-the-badge&logo=css3&logoColor=white)](https://github.com/css-modules/css-modules)
-![Firebase Hosting](https://img.shields.io/badge/Hosted%20on-Firebase%20Hosting-orange?style=for-the-badge&logo=firebase)
+[Open the live site](https://taca-da-pinga.web.app/)
 
-![Made with Love](https://img.shields.io/badge/Made%20with-%F0%9F%8D%BA%20and%20%F0%9F%92%9C-ff69b4?style=for-the-badge)
+## What it does
 
-![CI](https://github.com/OFranjas/taca-da-pinga/actions/workflows/ci.yml/badge.svg)
-[![License: MIT](https://cdn.prod.website-files.com/5e0f1144930a8bc8aace526c/65dd9eb5aaca434fac4f1c34_License-MIT-blue.svg)](/LICENSE)
-
-A React and Firebase app for live tournament scoring. Visitors can follow the leaderboard without signing in; authorised administrators manage teams, score configured drinks, update tournament branding and manage sponsor placements.
-
-**Live site:** [taca-da-pinga.web.app](https://taca-da-pinga.web.app/)
-
----
-
-## ✨ Features
-
-- **Live leaderboard** – Teams update immediately as scores are recorded, with responsive comparison bars.
-- **Drink scoring** – Admins record configured drinks; the app derives the pinga total and preserves a per-drink breakdown.
-- **Admin tools** – Create and manage teams, edit sponsors, and update the tournament logo and icon.
-- **Display mode** – A presentation-focused `/display` route for a TV or shared screen.
-- **Sponsor rails** – Accessible, motion-aware sponsor presentation across desktop, display and mobile layouts.
-- **PWA support** – Installable app shell and service worker for a more app-like tournament experience.
-
-See [the admin guide](docs/ADMIN.md) for the operational workflow and [the drinks catalogue](docs/CONFIG.md#developer-owned-drinks-catalogue) for the currently configured scores.
+- Shows a live public leaderboard.
+- Lets authorised administrators score drinks, manage teams, sponsors and branding.
+- Provides a dedicated display mode for a TV or shared screen.
+- Runs on React, Firebase and Vite, with an installable PWA shell.
 
 ## Routes
 
-| Route                 | Purpose                                                  | Access     |
-| --------------------- | -------------------------------------------------------- | ---------- |
-| `/`                   | Tournament home and sponsor presentation                 | Public     |
-| `/leaderboard`        | Interactive live leaderboard                             | Public     |
-| `/display` (or `/tv`) | Presentation-first leaderboard for a TV or shared screen | Public     |
-| `/admin`              | Scoring, teams and sponsor management                    | Admin only |
-| `/admin/branding`     | Logo and icon management                                 | Admin only |
+| Route                 | Purpose                      |
+| --------------------- | ---------------------------- |
+| `/`                   | Tournament home              |
+| `/leaderboard`        | Live leaderboard             |
+| `/display` (or `/tv`) | TV and shared-screen display |
+| `/admin`              | Admin operations             |
+| `/admin/branding`     | Branding management          |
 
-The service worker is registered only in production builds. It caches the app shell for installation and faster repeat visits, but live Firebase data still requires a network connection.
+## Quick start
 
----
+Requires Node.js 22.19.0 and Corepack.
 
-## 📸 Screenshots
-
-### Leaderboard
-
-| Desktop View                                              | Mobile View                                              |
-| --------------------------------------------------------- | -------------------------------------------------------- |
-| ![Leaderboard Screenshot](./docs/Leaderboard_Desktop.png) | ![Leaderboard Screenshot](./docs/Leaderboard_Mobile.png) |
-
-### Admin
-
-#### Add Pingas
-
-| Desktop View                                      | Mobile View                               |
-| ------------------------------------------------- | ----------------------------------------- |
-| ![Add Pingas](./docs/Admin_AddPingas_Desktop.png) | ![Add Pingas](./docs/Admin_AddPingas.png) |
-
-#### Manage Teams
-
-| Desktop View                                          | Mobile View                                   |
-| ----------------------------------------------------- | --------------------------------------------- |
-| ![Manage Teams](./docs/Admin_ManageTeams_Desktop.png) | ![Manage Teams](./docs/Admin_ManageTeams.png) |
-
----
-
-## 🚀 Getting Started
-
-#### Prerequisites
-
-- Node.js v22.19.0 (see `.nvmrc`)
-- Corepack (bundled with Node 22; run `corepack enable`)
-
-#### Installation
-
-```
-# Clone the repository
-git clone https://github.com/OFranjas/taca-da-pinga.git
-
-# Enable Corepack and install deps
+```bash
 corepack enable
 yarn install
-```
-
-#### Development
-
-```
 yarn dev
 ```
 
-Runs the app in development mode (Vite) at http://localhost:5173 with HMR.
+The app runs at <http://localhost:5173>. Use `yarn build` to create a production build and `yarn preview` to test it locally.
 
-#### Build
+## Validation
 
-```
+```bash
+yarn lint
+yarn typecheck
+yarn test:ci
+yarn test:rules
 yarn build
 ```
 
-Builds the app for production to the `dist` folder (Vite). Use `yarn preview` to locally preview the production build.
+## Delivery
 
-#### Testing
-
-```
-yarn test        # unit + component (Vitest)
-yarn test:ci     # CI mode with coverage
-yarn test:rules  # Firestore security rules (emulator)
-yarn lint        # lint source files
-yarn typecheck   # TypeScript checks
-yarn build       # production build
-```
-
-## 🔀 Branching Model
-
-- `feature/*` → short-lived feature branches, branched from `develop`
-- `develop` → integration branch (feature PRs merge here)
-- `production` → production-ready branch (protected)
-
-### PR Rules
-
-- Into `develop`: CI must be green.
-- Into `production`: CI must be green **and** at least 1 approval from code owner.
-- Required CI check name: **CI / Lint / Typecheck / Test / Build**
-
-### CI & Deployments
-
-- **PR Preview** – Every pull request builds the app in GitHub Actions and publishes a Firebase Hosting preview at [`https://preview-taca-da-pinga.web.app`](https://preview-taca-da-pinga.web.app). The job reuses the preview channel, so reruns refresh the same URL.
-- **Deploy Develop** – Merges to `develop` rerun lint/test/typecheck/build and deploy the bundle to the dedicated Hosting site [`https://develop-taca-da-pinga.web.app`](https://develop-taca-da-pinga.web.app).
-- Both workflows require the Firebase web config secrets (`VITE_FIREBASE_*`) and a `FIREBASE_SERVICE_ACCOUNT` with Hosting + Rules deploy permissions. See [docs/CONFIG.md](docs/CONFIG.md#github-secrets) for the list.
-
-See [`AGENTS.md`](./AGENTS.md) for exact agent/developer workflows.
-
----
-
-## Firestore Emulator
-
-Security rules tests run against the Firestore emulator. The `yarn test:rules` script automatically downloads and starts the emulator before executing the tests.
-
-If you prefer to keep the emulator running for multiple test iterations, start it manually in another terminal:
-
-```
-firebase emulators:start --only firestore
-```
-
-Then run the tests separately:
-
-```
-yarn --cwd rules-tests test
-```
-
-### Admin access (custom claims)
-
-Admin-only Firestore writes are gated by a custom claim: `admin: true`.  
-Grant/revoke admin locally (no Cloud Functions required). See [docs/DEV.md](docs/DEV.md#admin-custom-claims).
+Feature branches merge into `develop`; production releases are promoted from `develop` to `production`. Pull requests publish a preview, and merges to `develop` deploy to [develop-taca-da-pinga.web.app](https://develop-taca-da-pinga.web.app/). Production deployment is manual.
 
 ## Documentation
 
-- [Admin guide](docs/ADMIN.md) – daily tournament operations and access.
-- [Developer guide](docs/DEV.md) – local setup, emulators and admin-claim tooling.
-- [Configuration](docs/CONFIG.md) – Firebase environments, secrets and data model.
-- [Testing](docs/TESTING.md) – test commands and Firestore invariants.
-- [Release](docs/RELEASE.md) – production checklist and rollback.
-- [Security](docs/SECURITY.md) – security model and operational boundaries.
+- [Admin guide](docs/ADMIN.md)
+- [Developer guide](docs/DEV.md)
+- [Configuration](docs/CONFIG.md)
+- [Testing](docs/TESTING.md)
+- [Release and rollback](docs/RELEASE.md)
+- [Security model](docs/SECURITY.md)
 
-## 📄 License
+## License
 
-This project is licensed under the MIT License. Check the [LICENSE](./LICENSE) file for more details.
-
-## ⚠️ Disclaimer
-
-This project was created as a lightweight, fun leaderboard system for a friendly competition.
-Some logos and assets are used for demonstration purposes only and may be subject to copyright or restricted use.
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🏆 Taça da Pinga
 
-> Real-time leaderboard app for a friendly football tournament — with beer points instead of goals 🍺
+> A real-time tournament leaderboard for tracking drinks as **pingas** 🍺
 
 [![React](https://img.shields.io/badge/React-20232A?style=for-the-badge&logo=react&logoColor=61DAFB)](https://react.dev/)[![Firebase](https://img.shields.io/badge/Firebase-ffca28?style=for-the-badge&logo=firebase&logoColor=black)](https://firebase.google.com/)[![Recharts](https://img.shields.io/badge/Recharts-FF6384?style=for-the-badge&logo=chart.js&logoColor=white)](https://recharts.org/)[![CSS Modules](https://img.shields.io/badge/CSS%20Modules-000000?style=for-the-badge&logo=css3&logoColor=white)](https://github.com/css-modules/css-modules)
 ![Firebase Hosting](https://img.shields.io/badge/Hosted%20on-Firebase%20Hosting-orange?style=for-the-badge&logo=firebase)
@@ -10,22 +10,34 @@
 ![CI](https://github.com/OFranjas/taca-da-pinga/actions/workflows/ci.yml/badge.svg)
 [![License: MIT](https://cdn.prod.website-files.com/5e0f1144930a8bc8aace526c/65dd9eb5aaca434fac4f1c34_License-MIT-blue.svg)](/LICENSE)
 
-A small web application built with **React** and **Firebase** to manage a fun "beer points" leaderboard for a local football tournament.  
-Participants can see the leaderboard in real-time, and admins can add points (_pingas_) from a protected admin panel.
+A React and Firebase app for live tournament scoring. Visitors can follow the leaderboard without signing in; authorised administrators manage teams, score configured drinks, update tournament branding and manage sponsor placements.
 
-Originally developed in a couple of days as a request for a friend, this project also served as a hands-on opportunity to practice **React** development, **Firebase** integration, and responsive UI design.
-
-🚀 <a href="https://taca-da-pinga.web.app/" target="_blank"><strong>Click here to view the live demo</strong></a> 🚀
+**Live site:** [taca-da-pinga.web.app](https://taca-da-pinga.web.app/)
 
 ---
 
 ## ✨ Features
 
-- **Real-time Leaderboard** – Updates instantly as scores change.
-- **Admin Panel** – Secure login for managing teams and recording configured drinks with their pinga values.
-- **Responsive Design** – Optimized for desktop, TV display, and mobile.
-- **Firebase Integration** – Authentication & Firestore database.
-- **Sponsor Rail** – Displays tournament sponsors.
+- **Live leaderboard** – Teams update immediately as scores are recorded, with responsive comparison bars.
+- **Drink scoring** – Admins record configured drinks; the app derives the pinga total and preserves a per-drink breakdown.
+- **Admin tools** – Create and manage teams, edit sponsors, and update the tournament logo and icon.
+- **Display mode** – A presentation-focused `/display` route for a TV or shared screen.
+- **Sponsor rails** – Accessible, motion-aware sponsor presentation across desktop, display and mobile layouts.
+- **PWA support** – Installable app shell and service worker for a more app-like tournament experience.
+
+See [the admin guide](docs/ADMIN.md) for the operational workflow and [the drinks catalogue](docs/CONFIG.md#developer-owned-drinks-catalogue) for the currently configured scores.
+
+## Routes
+
+| Route                 | Purpose                                                  | Access     |
+| --------------------- | -------------------------------------------------------- | ---------- |
+| `/`                   | Tournament home and sponsor presentation                 | Public     |
+| `/leaderboard`        | Interactive live leaderboard                             | Public     |
+| `/display` (or `/tv`) | Presentation-first leaderboard for a TV or shared screen | Public     |
+| `/admin`              | Scoring, teams and sponsor management                    | Admin only |
+| `/admin/branding`     | Logo and icon management                                 | Admin only |
+
+The service worker is registered only in production builds. It caches the app shell for installation and faster repeat visits, but live Firebase data still requires a network connection.
 
 ---
 
@@ -92,7 +104,10 @@ Builds the app for production to the `dist` folder (Vite). Use `yarn preview` to
 ```
 yarn test        # unit + component (Vitest)
 yarn test:ci     # CI mode with coverage
-npm run test:rules  # Firestore security rules (emulator)
+yarn test:rules  # Firestore security rules (emulator)
+yarn lint        # lint source files
+yarn typecheck   # TypeScript checks
+yarn build       # production build
 ```
 
 ## 🔀 Branching Model
@@ -138,13 +153,14 @@ yarn --cwd rules-tests test
 Admin-only Firestore writes are gated by a custom claim: `admin: true`.  
 Grant/revoke admin locally (no Cloud Functions required). See [docs/DEV.md](docs/DEV.md#admin-custom-claims).
 
-## Runbook
+## Documentation
 
-- Local dev: [docs/DEV.md](docs/DEV.md)
-- Config/env: [docs/CONFIG.md](docs/CONFIG.md)
-- Testing: [docs/TESTING.md](docs/TESTING.md)
-- Release: [docs/RELEASE.md](docs/RELEASE.md)
-- Security: [docs/SECURITY.md](docs/SECURITY.md)
+- [Admin guide](docs/ADMIN.md) – daily tournament operations and access.
+- [Developer guide](docs/DEV.md) – local setup, emulators and admin-claim tooling.
+- [Configuration](docs/CONFIG.md) – Firebase environments, secrets and data model.
+- [Testing](docs/TESTING.md) – test commands and Firestore invariants.
+- [Release](docs/RELEASE.md) – production checklist and rollback.
+- [Security](docs/SECURITY.md) – security model and operational boundaries.
 
 ## 📄 License
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ yarn build
 
 ## Delivery
 
-Feature branches merge into `develop`; production releases are promoted from `develop` to `production`. Pull requests publish a preview, and merges to `develop` deploy to [develop-taca-da-pinga.web.app](https://develop-taca-da-pinga.web.app/). Production deployment is manual.
+Feature branches merge into `develop`; production releases are promoted from `develop` to `production`. Pull requests publish a preview, merges to `develop` deploy to [develop-taca-da-pinga.web.app](https://develop-taca-da-pinga.web.app/), and merges to `production` deploy the production Firebase project.
 
 ## Documentation
 

--- a/docs/ADMIN.md
+++ b/docs/ADMIN.md
@@ -1,0 +1,62 @@
+# Tournament Admin Guide
+
+## Access
+
+The public leaderboard does not need a login. Administrative actions require a
+Firebase Authentication account whose ID token has the custom claim
+`admin: true`. A successful email/password login without that claim cannot
+write tournament data.
+
+For local claim-management instructions, see [DEV.md](DEV.md#admin-custom-claims).
+After a claim changes, the administrator must sign out and back in to refresh
+their Firebase ID token.
+
+## Daily scoring
+
+1. Sign in at `/admin`.
+2. Select the team and the drink or drinks served.
+3. Confirm the score. The app calculates the total number of pingas from the
+   configured catalogue and records the drink breakdown with the score event.
+4. Verify the team moves on the public leaderboard.
+
+The current catalogue is maintained in `src/config/drinks.ts`. Its IDs are used
+in historical score records, so do not rename or reuse an ID after it has been
+scored. A single submission must add from 1 to 50 pingas.
+
+## Managing teams
+
+Use the **Manage teams** section in the admin panel to add a team before play
+begins or remove one that was created by mistake. Team totals are protected by
+Firestore rules: only admins can write, score totals cannot be reduced, and a
+score increment is capped at 50 pingas.
+
+## Managing sponsors
+
+The admin panel can create, edit, reorder, activate, deactivate and remove
+sponsors. A sponsor card needs a name, an image data URL and an order from 0 to
+999; its optional destination must be an `https://` URL. Inactive sponsors stay
+available to administrators but are not shown publicly.
+
+## Sponsors and branding
+
+- Use the sponsor management section to add, reorder, activate or deactivate
+  sponsor cards. Sponsor links must use `https://` (or be empty).
+- Use **Branding** to update the primary logo and app icon. Images are stored as
+  image data URLs and are limited to 180 KB each.
+- Check both the public leaderboard and `/display` after material sponsor or
+  branding changes.
+
+## Display mode
+
+Open `/display` on the presentation device. It uses the same live leaderboard
+data as the public route and is designed for a TV or shared screen. The admin
+panel includes an **Abrir modo TV** shortcut that opens it in a new tab.
+
+## Before the event
+
+- Confirm every administrator can sign in and has the `admin: true` claim.
+- Add the intended teams and verify the score flow with a low-value drink.
+- Check the public leaderboard on mobile and the display route on the event
+  screen.
+- Confirm sponsor links, ordering and branding assets.
+- Keep the production release and rollback procedure available: [RELEASE.md](RELEASE.md).

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -15,7 +15,10 @@ VITE_FIREBASE_APP_ID=
 
 ## GitHub Secrets
 
-The CI/CD workflows rely on the same Firebase configuration. Add these repository secrets:
+The CI/CD workflows need Firebase configuration. Use repository secrets for
+preview and `develop`. Configure a GitHub environment named `production` with
+the distinct production-only secrets below for the production deployment
+workflow.
 
 | Secret                              | Required | Description                                                                      |
 | ----------------------------------- | -------- | -------------------------------------------------------------------------------- |
@@ -25,10 +28,28 @@ The CI/CD workflows rely on the same Firebase configuration. Add these repositor
 | `VITE_FIREBASE_STORAGE_BUCKET`      | ✅       | Firebase client config                                                           |
 | `VITE_FIREBASE_MESSAGING_SENDER_ID` | ✅       | Firebase client config                                                           |
 | `VITE_FIREBASE_APP_ID`              | ✅       | Firebase client config                                                           |
-| `FIREBASE_SERVICE_ACCOUNT`          | ✅       | Base64/JSON service account with Hosting + Firestore Rules deploy permissions    |
+| `FIREBASE_SERVICE_ACCOUNT`          | ✅       | JSON service account with Hosting + Firestore Rules deploy permissions           |
 | `FIREBASE_PROJECT_ID`               | ⬜       | Override when the repo default project differs from the service account defaults |
 
 > The service account must be able to create Hosting channels/sites and deploy Firestore rules (e.g. roles: `Firebase Hosting Admin` + `Firebase Rules Admin`).
+
+The `Deploy Production` workflow is bound to the GitHub `production`
+environment. Add these secrets there (do not reuse the repository-secret
+names):
+
+- `PRODUCTION_VITE_FIREBASE_API_KEY`
+- `PRODUCTION_VITE_FIREBASE_AUTH_DOMAIN`
+- `PRODUCTION_VITE_FIREBASE_PROJECT_ID`
+- `PRODUCTION_VITE_FIREBASE_STORAGE_BUCKET`
+- `PRODUCTION_VITE_FIREBASE_MESSAGING_SENDER_ID`
+- `PRODUCTION_VITE_FIREBASE_APP_ID`
+- `PRODUCTION_FIREBASE_PROJECT_ID`
+- `PRODUCTION_FIREBASE_SERVICE_ACCOUNT`
+
+This makes a merge to `production` fail safely until its production-only
+configuration exists, rather than falling back to `develop` credentials. Add
+required reviewers to the GitHub environment only if a post-merge approval gate
+is desired before production deployment.
 
 ## Runtime Data
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -30,9 +30,11 @@ The CI/CD workflows rely on the same Firebase configuration. Add these repositor
 
 > The service account must be able to create Hosting channels/sites and deploy Firestore rules (e.g. roles: `Firebase Hosting Admin` + `Firebase Rules Admin`).
 
-## Runtime Config
+## Runtime Data
 
-- Admin allowlist: `app_config/admins` document in Firestore (or custom claim `admin`).
+- Admin authorization is exclusively controlled by the Firebase Auth custom
+  claim `admin: true`. The app and Firestore rules do not consult an
+  `app_config/admins` allowlist.
 - Collections:
   - `teams`: { id, name, pingas, drinkTotals }
     - `pingas` remains the public leaderboard total.
@@ -68,6 +70,12 @@ reset plan. Do not run destructive deletion commands by default.
 
 - Separate Firebase projects for `develop` and `production`.
 - Never reuse prod keys locally.
+
+## PWA cache behaviour
+
+Production builds register a service worker that caches the application shell
+and runtime static assets. Firestore data remains live and network-backed, so
+the leaderboard and admin tools are not supported as offline data-entry tools.
 
 ## Admin claims configuration
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -31,7 +31,9 @@ workflow.
 | `FIREBASE_SERVICE_ACCOUNT`          | ✅       | JSON service account with Hosting + Firestore Rules deploy permissions           |
 | `FIREBASE_PROJECT_ID`               | ⬜       | Override when the repo default project differs from the service account defaults |
 
-> The service account must be able to create Hosting channels/sites and deploy Firestore rules (e.g. roles: `Firebase Hosting Admin` + `Firebase Rules Admin`).
+> The service account must be able to create Hosting channels/sites and deploy
+> Firestore rules and indexes (e.g. roles: `Firebase Hosting Admin` + `Firebase
+Rules Admin` + `Cloud Datastore Index Admin` (`roles/datastore.indexAdmin`)).
 
 The `Deploy Production` workflow is bound to the GitHub `production`
 environment. Add these secrets there (do not reuse the repository-secret

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -21,7 +21,8 @@
 
 The `Deploy Production` workflow runs automatically after a merge to
 `production`. It validates, builds, deploys Firestore rules and indexes, then
-deploys Firebase Hosting.
+deploys the `taca-da-pinga` Firebase Hosting site. Manual workflow runs are
+allowed only when the selected ref is `production`.
 
 Configure the GitHub **production** environment with the `PRODUCTION_*` secrets
 listed in [CONFIG.md](CONFIG.md#github-secrets). The service account needs

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -8,8 +8,13 @@
 
 ## Pre-merge to `production`
 
-- [ ] CI green on `develop`
-- [ ] Changelog entry if needed
+- [ ] The `develop` → `production` PR is current and mergeable.
+- [ ] **CI / Lint / Typecheck / Test / Build** is green for the PR head.
+- [ ] The PR preview or `develop` deployment has been visually checked on desktop and mobile.
+- [ ] Firestore rules and indexes are included when their source files changed.
+- [ ] Required approval is recorded (production requires at least one approval).
+- [ ] Firebase production configuration and the admin access plan have been confirmed.
+- [ ] Release notes or a changelog entry have been added when user-visible behaviour changed.
 
 ## Deploy (human owner)
 
@@ -21,8 +26,17 @@ firebase deploy --only hosting,firestore:rules,firestore:indexes
 
 > The service account used by the automation must have permission to deploy Hosting **and** Firestore rules (e.g. Firebase Hosting Admin + Firebase Rules Admin). Grant the same roles locally (or run deploys with an owner account) to avoid 403 errors.
 
+## Post-deploy verification
+
+- [ ] Smoke-test `/`, `/leaderboard`, `/display` and `/admin` against the
+      production Firebase project.
+- [ ] Confirm the live leaderboard receives an expected update and that an
+      authorised admin can sign in.
+
 ## Rollback
 
 - Revert merge commit (git revert -m 1 <sha>)
 
 - Redeploy rules/hosting with the previous known-good commit
+
+- Record the reverted commit and repeat the post-deploy verification checks.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -26,9 +26,9 @@ allowed only when the selected ref is `production`.
 
 Configure the GitHub **production** environment with the `PRODUCTION_*` secrets
 listed in [CONFIG.md](CONFIG.md#github-secrets). The service account needs
-Firebase Hosting Admin and Firebase Rules Admin permissions for that production
-project. Required reviewers are optional if a post-merge approval gate is
-desired.
+Firebase Hosting Admin, Firebase Rules Admin, and Cloud Datastore Index Admin
+(`roles/datastore.indexAdmin`) permissions for that production project. Required
+reviewers are optional if a post-merge approval gate is desired.
 
 ## Post-deploy verification
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -4,7 +4,8 @@
 
 - Pull requests automatically publish previews at `https://preview-taca-da-pinga.web.app`.
 - Merges to `develop` auto-deploy to `https://develop-taca-da-pinga.web.app` after re-running lint/tests/build.
-- Production deploys remain manual (below).
+- Merges to `production` run the production deployment workflow after its
+  validation steps pass.
 
 ## Pre-merge to `production`
 
@@ -16,15 +17,17 @@
 - [ ] Firebase production configuration and the admin access plan have been confirmed.
 - [ ] Release notes or a changelog entry have been added when user-visible behaviour changed.
 
-## Deploy (human owner)
+## Production deployment
 
-```bash
-firebase use <prod-project-id>
-yarn build
-firebase deploy --only hosting,firestore:rules,firestore:indexes
-```
+The `Deploy Production` workflow runs automatically after a merge to
+`production`. It validates, builds, deploys Firestore rules and indexes, then
+deploys Firebase Hosting.
 
-> The service account used by the automation must have permission to deploy Hosting **and** Firestore rules (e.g. Firebase Hosting Admin + Firebase Rules Admin). Grant the same roles locally (or run deploys with an owner account) to avoid 403 errors.
+Configure the GitHub **production** environment with the `PRODUCTION_*` secrets
+listed in [CONFIG.md](CONFIG.md#github-secrets). The service account needs
+Firebase Hosting Admin and Firebase Rules Admin permissions for that production
+project. Required reviewers are optional if a post-merge approval gate is
+desired.
 
 ## Post-deploy verification
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -3,7 +3,8 @@
 ## AuthN / AuthZ
 
 - Public can read leaderboard & events without auth.
-- Admins authenticated via Firebase Auth; authorized via custom claim `admin` or email in `app_config/admins`.
+- Admins authenticate with Firebase Auth and are authorized exclusively by the
+  custom claim `admin: true`.
 
 ## Firestore Rules (sketch)
 
@@ -29,16 +30,29 @@ service cloud.firestore {
       allow write: if isAdmin();
       allow read: if false;                     // not publicly readable
     }
+    // Branding and sponsors
+    match /branding/current {
+      allow read: if true;
+      allow write: if isAdmin();                // image data is separately validated
+    }
+    match /sponsors/{sponsorId} {
+      allow read: if true;
+      allow write: if isAdmin();                // fields and HTTPS links are validated
+    }
   }
 }
 ```
 
 ## Invariants
 
-- Only admins can mutate (`teams`, `events`, `app_config`).
-- Public can read `teams` and `events`; `app_config` is not publicly readable.
+- Only admins can mutate `teams`, `events`, `app_config`, branding and sponsors.
+- Public can read `teams`, `events`, `branding/current` and sponsors;
+  `app_config` is not publicly readable.
 - “Add pinga” increments are positive and bounded (delta ∈ [1..50]).
 - Totals never negative.
+- Branding and sponsor images must be image data URLs at most 180 KB. Sponsor
+  names are limited to 80 characters, links must be HTTPS (or empty), and
+  ordering is bounded from 0 to 999.
 - Drink scoring is service-owned: the service validates active catalogue IDs,
   quantities, derived line deltas, duplicate consolidation, and receipt/projection
   consistency before committing one batch. Rules do not attempt to validate

--- a/docs/SPONSORS.md
+++ b/docs/SPONSORS.md
@@ -1,6 +1,11 @@
 # Sponsors
 
-Sponsor logos are managed from the admin panel and rendered in three places:
+Sponsor logos are managed from the admin panel. Administrators can create,
+edit, reorder, activate, deactivate and delete sponsor cards. Each card needs a
+name, image data URL, active flag and an order from 0 to 999; its optional link
+must use `https://`.
+
+Active sponsor cards are rendered in three places:
 
 - Home page sponsor strip
 - Mobile leaderboard strip above the table
@@ -9,3 +14,7 @@ Sponsor logos are managed from the admin panel and rendered in three places:
 Mobile/tablet sponsor strips use a shared transform-based auto-scroll controller. It preserves horizontal dragging and touch swiping, pauses while a user hovers, focuses or touches the strip, resumes after a short idle delay, and disables movement when the device requests reduced motion. Keep this behaviour in `SponsorMarquee`; do not add page-specific carousels.
 
 Desktop and display side rails can auto-scroll vertically because they are presentation-first surfaces and do not compete with touch dragging in the main mobile flow.
+
+After changing sponsor content, check the home page, mobile leaderboard and
+`/display`. Inactive sponsors are retained for administrators but are hidden
+from every public placement.

--- a/rules-tests/firestore.rules.test.js
+++ b/rules-tests/firestore.rules.test.js
@@ -55,11 +55,15 @@ function makeDb(mockUserToken) {
   return { app, db };
 }
 
+function makeAdminDb(uid = 'rules-admin') {
+  return makeDb({ sub: uid, user_id: uid, admin: true });
+}
+
 describe('Firestore security rules', () => {
   test('public reads allowed for teams and events', async () => {
-    const { db: ownerDb } = makeDb('owner');
-    await setDoc(doc(ownerDb, 'teams/t1'), { name: 'Team 1', pingas: 0 });
-    await setDoc(doc(ownerDb, 'events/e1'), { type: 'bootstrap' });
+    const { db: adminDb } = makeAdminDb('public-read-seed');
+    await setDoc(doc(adminDb, 'teams/t1'), { name: 'Team 1', pingas: 0 });
+    await setDoc(doc(adminDb, 'events/e1'), { type: 'bootstrap' });
 
     const { db: anonDb } = makeDb(undefined);
     await assertSucceeds(getDoc(doc(anonDb, 'teams/t1')));
@@ -67,8 +71,8 @@ describe('Firestore security rules', () => {
   });
 
   test('non-admin writes denied everywhere (teams, events, app_config)', async () => {
-    const { db: ownerDb } = makeDb('owner');
-    await setDoc(doc(ownerDb, 'teams/t1'), { name: 'Team 1', pingas: 0 });
+    const { db: adminDb } = makeAdminDb('non-admin-write-seed');
+    await setDoc(doc(adminDb, 'teams/t1'), { name: 'Team 1', pingas: 0 });
 
     const { db: anonDb } = makeDb(undefined);
     await assertFails(setDoc(doc(anonDb, 'teams/x'), { name: 'X', pingas: 0 }));
@@ -112,12 +116,12 @@ describe('Firestore security rules', () => {
     await assertSucceeds(updateDoc(doc(adminDb, 'teams/a1'), { pingas: 53 })); // 3 -> 53 (+50)
 
     // Out-of-range increments denied (>50)
-    const { db: ownerDb } = makeDb('owner');
-    await setDoc(doc(ownerDb, 'teams/b1'), { name: 'B', pingas: 0 });
+    const { db: seedDb } = makeAdminDb('increment-seed');
+    await setDoc(doc(seedDb, 'teams/b1'), { name: 'B', pingas: 0 });
     await assertFails(updateDoc(doc(adminDb, 'teams/b1'), { pingas: 51 })); // 0 -> 51 (+51)
 
     // Negative increments denied; totals never negative
-    await setDoc(doc(ownerDb, 'teams/c1'), { name: 'C', pingas: 2 });
+    await setDoc(doc(seedDb, 'teams/c1'), { name: 'C', pingas: 2 });
     await assertFails(updateDoc(doc(adminDb, 'teams/c1'), { pingas: 1 })); // 2 -> 1 (-1)
     await assertFails(updateDoc(doc(adminDb, 'teams/c1'), { pingas: -1 })); // negative total
 
@@ -131,8 +135,8 @@ describe('Firestore security rules', () => {
 
   test('app_config reads are not public', async () => {
     {
-      const { db: ownerDb2 } = makeDb('owner');
-      await setDoc(doc(ownerDb2, 'app_config/main'), { feature: 'x' });
+      const { db: adminDb } = makeAdminDb('app-config-seed');
+      await setDoc(doc(adminDb, 'app_config/main'), { feature: 'x' });
     }
 
     const { db: anonDb2 } = makeDb(undefined);


### PR DESCRIPTION
## What

- Fix Firestore rules-test fixtures to seed protected documents with an admin custom claim.
- Refresh the README with current product capabilities, routes, validation commands and documentation links.
- Add an admin operations guide and update configuration, security, sponsor and release runbooks for the production workflow.

## Why

The production promotion review identified that rules-test seed writes no longer satisfy the admin-only Firestore rules. The release also needs accurate, operator-ready documentation before it is promoted to production.

## Impact

- `yarn test:rules` can now validate the intended Firestore rule assertions.
- Tournament administrators have clear guidance for scoring, teams, sponsors, branding and display mode.
- Release operators have an ordered pre-merge, deploy and post-deploy checklist.

## Checks

- `yarn test:rules` — passed (9 tests).
- `yarn lint` — passed.
- `yarn typecheck` — passed.
- `git diff --check` — passed.

## Reviewer notes

This branch addresses the P1 review feedback from production PR #42. It does not update or resolve that release PR directly; merge this PR into `develop`, then refresh #42.