### PR TITLE
fix: enforce drink score projection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Purpose: This file briefs AI coding agents (e.g., Codex) on how to work in this 
   - `taca-da-pinga` (main)
   - `preview-taca-da-pinga` (PR previews)
   - `develop-taca-da-pinga` (auto-deploy for develop)
-- Services: `src/services/leaderboard.js` (getLeaderboard, observeLeaderboard, addPinga, listEvents), `src/services/teams.js` (observeTeamsOrderedByName, createTeamIfNotExists, deleteTeam).
+- Services: `src/services/leaderboard.js` (getLeaderboard, observeLeaderboard, addDrinkPingas, listEvents), `src/services/teams.js` (observeTeamsOrderedByName, createTeamIfNotExists, deleteTeam).
 
 ## Branching & PR Rules
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -75,6 +75,9 @@ lowercase kebab-case `id`, Portuguese `name`, positive integer `pingaValue`,
 `active` flag, `order`, a typed fallback `icon`, and optional local `imageSrc`.
 The catalogue is bundled with the application; it is not read from `app_config`
 or Firestore. IDs must not be renamed or recycled after scoring data uses them.
+The Firestore rules mirror the active Phase 1 IDs and pinga values so they can
+authoritatively validate the stored `drinkTotals` projection; update the rules
+and their emulator tests whenever this catalogue changes.
 
 Each submission uses the derived catalogue total and must be between 1 and 50
 pingas. The UI, service, and Firestore Rules enforce this bound.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -55,9 +55,9 @@ service cloud.firestore {
   ordering is bounded from 0 to 999.
 - Drink scoring is service-owned: the service validates active catalogue IDs,
   quantities, derived line deltas, duplicate consolidation, and receipt/projection
-  consistency before committing one batch. Rules do not attempt to validate
-  arbitrary dynamic receipt sums, but still enforce authorization and the score
-  increment bound.
+  consistency before committing one batch. Firestore rules mirror the fixed
+  Phase 1 drink catalogue and enforce the quantity/pinga arithmetic and total
+  score delta for its `drinkTotals` projection.
 
 ## Logging & Audit
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -68,6 +68,7 @@ git grep "from 'firebase/firestore'" src/components src/pages
 
 Rules tests live under `rules-tests/` and run via `yarn test:rules`.
 
-The service validates dynamic drink receipt consistency. The current client-write
-rules intentionally cannot prove an arbitrary receipt item sum, but continue to
-enforce admin-only writes and the authoritative 1–50 positive team increment.
+The service validates the immutable drink receipt. Firestore rules mirror the
+fixed Phase 1 catalogue and enforce that each `drinkTotals` quantity/pinga delta
+uses the configured value and that the combined projection delta matches the
+authoritative 1–50 team-score increment.

--- a/firestore.rules
+++ b/firestore.rules
@@ -53,6 +53,10 @@ service cloud.firestore {
         isValidDrinkTotal(totals, 'metro', 11);
     }
 
+    function hasEmptyDrinkTotals(totals) {
+      return totals is map && totals.keys().size() == 0;
+    }
+
     function drinkDeltaMatchesValue(before, after, drinkId, pingaValue) {
       return drinkQuantity(after, drinkId) >= drinkQuantity(before, drinkId) &&
         drinkPingas(after, drinkId) >= drinkPingas(before, drinkId) &&
@@ -85,7 +89,7 @@ service cloud.firestore {
       allow create: if isAdmin() &&
         // New teams begin with no score and an empty (or absent) projection.
         request.resource.data.pingas is int && request.resource.data.pingas == 0 &&
-        hasValidDrinkTotals(drinkTotals(request.resource.data));
+        hasEmptyDrinkTotals(drinkTotals(request.resource.data));
 
       allow update: if isAdmin() && (
         // Metadata-only edits are allowed, but the service-owned drink projection

--- a/firestore.rules
+++ b/firestore.rules
@@ -95,8 +95,8 @@ service cloud.firestore {
         // Metadata-only edits are allowed, but the service-owned drink projection
         // cannot change without a score increment.
         (
-          !(request.resource.data.diff(resource.data).changedKeys().hasAny(['pingas'])) &&
-          !(request.resource.data.diff(resource.data).changedKeys().hasAny(['drinkTotals']))
+          !(request.resource.data.diff(resource.data).affectedKeys().hasAny(['pingas'])) &&
+          !(request.resource.data.diff(resource.data).affectedKeys().hasAny(['drinkTotals']))
         ) ||
         // If pingas changes, enforce bounds and positivity, and types
         (

--- a/firestore.rules
+++ b/firestore.rules
@@ -22,15 +22,70 @@ service cloud.firestore {
       return isDataUrl(dataUrl) && dataUrl.size() <= maxImgLen();
     }
 
+    // The Phase 1 drinks catalogue is deliberately mirrored here so that the
+    // client-maintained team projection remains verifiable at the trust boundary.
+    function drinkTotals(data) {
+      return data.get('drinkTotals', {});
+    }
+
+    function drinkQuantity(totals, drinkId) {
+      return totals.get(drinkId, {}).get('quantity', 0);
+    }
+
+    function drinkPingas(totals, drinkId) {
+      return totals.get(drinkId, {}).get('pingas', 0);
+    }
+
+    function isValidDrinkTotal(totals, drinkId, pingaValue) {
+      let total = totals.get(drinkId, {});
+      return total is map &&
+        total.keys().hasOnly(['quantity', 'pingas']) &&
+        drinkQuantity(totals, drinkId) is int && drinkQuantity(totals, drinkId) >= 0 &&
+        drinkPingas(totals, drinkId) is int && drinkPingas(totals, drinkId) >= 0 &&
+        drinkPingas(totals, drinkId) == drinkQuantity(totals, drinkId) * pingaValue;
+    }
+
+    function hasValidDrinkTotals(totals) {
+      return totals is map &&
+        totals.keys().hasOnly(['light', 'white-spirit', 'metro']) &&
+        isValidDrinkTotal(totals, 'light', 1) &&
+        isValidDrinkTotal(totals, 'white-spirit', 5) &&
+        isValidDrinkTotal(totals, 'metro', 11);
+    }
+
+    function drinkDeltaMatchesValue(before, after, drinkId, pingaValue) {
+      return drinkQuantity(after, drinkId) >= drinkQuantity(before, drinkId) &&
+        drinkPingas(after, drinkId) >= drinkPingas(before, drinkId) &&
+        drinkPingas(after, drinkId) - drinkPingas(before, drinkId) ==
+          (drinkQuantity(after, drinkId) - drinkQuantity(before, drinkId)) * pingaValue;
+    }
+
+    function drinkPingasDelta(before, after) {
+      return (drinkPingas(after, 'light') - drinkPingas(before, 'light')) +
+        (drinkPingas(after, 'white-spirit') - drinkPingas(before, 'white-spirit')) +
+        (drinkPingas(after, 'metro') - drinkPingas(before, 'metro'));
+    }
+
+    function hasValidDrinkProjectionUpdate() {
+      let before = drinkTotals(resource.data);
+      let after = drinkTotals(request.resource.data);
+      return hasValidDrinkTotals(after) &&
+        drinkDeltaMatchesValue(before, after, 'light', 1) &&
+        drinkDeltaMatchesValue(before, after, 'white-spirit', 5) &&
+        drinkDeltaMatchesValue(before, after, 'metro', 11) &&
+        drinkPingasDelta(before, after) ==
+          request.resource.data.pingas - resource.data.pingas;
+    }
+
     // Leaderboard (teams) — public READ, admin WRITE with invariants
     match /teams/{teamId} {
       allow read: if true;
 
       // Create/update/delete only by admins
       allow create: if isAdmin() &&
-        // New documents must start with non-negative total
-        (!('pingas' in request.resource.data) ||
-          (request.resource.data.pingas is int && request.resource.data.pingas >= 0));
+        // New teams begin with no score and an empty (or absent) projection.
+        request.resource.data.pingas is int && request.resource.data.pingas == 0 &&
+        hasValidDrinkTotals(drinkTotals(request.resource.data));
 
       allow update: if isAdmin() && (
         // Metadata-only edits are allowed, but the service-owned drink projection
@@ -46,13 +101,10 @@ service cloud.firestore {
           request.resource.data.pingas >= 0 &&
           request.resource.data.pingas > resource.data.pingas &&
           (request.resource.data.pingas - resource.data.pingas) >= 1 &&
-          (request.resource.data.pingas - resource.data.pingas) <= 50
+          (request.resource.data.pingas - resource.data.pingas) <= 50 &&
+          hasValidDrinkProjectionUpdate()
         )
       );
-
-      // The service validates drinkTotals arithmetic and receipt consistency.
-      // Rules preserve authorization and the total increment bound, but cannot
-      // prove that arbitrary dynamic receipt items sum to this projection.
 
       allow delete: if isAdmin();
     }

--- a/rules-tests/firestore.rules.test.js
+++ b/rules-tests/firestore.rules.test.js
@@ -100,6 +100,18 @@ describe('Firestore security rules', () => {
     // Metadata-only updates are allowed.
     await assertSucceeds(updateDoc(doc(adminDb, 'teams/a1'), { name: 'Alpha' }));
 
+    // Teams start with no score and no attributed drinks.
+    await assertFails(
+      setDoc(doc(adminDb, 'teams/non-zero'), { name: 'Non-zero', pingas: 1 })
+    );
+    await assertFails(
+      setDoc(doc(adminDb, 'teams/unknown-drink'), {
+        name: 'Unknown drink',
+        pingas: 0,
+        drinkTotals: { cocktail: { quantity: 0, pingas: 0 } },
+      })
+    );
+
     // Allowed increments 1..50
     await assertSucceeds(
       updateDoc(doc(adminDb, 'teams/a1'), {
@@ -111,9 +123,42 @@ describe('Firestore security rules', () => {
 
     // A direct projection edit cannot bypass the bounded score increment.
     await assertFails(updateDoc(doc(adminDb, 'teams/a1'), { 'drinkTotals.light.quantity': 2 }));
+    // A score update must have a matching drink projection delta.
+    await assertFails(updateDoc(doc(adminDb, 'teams/a1'), { pingas: 2 }));
 
-    await assertSucceeds(updateDoc(doc(adminDb, 'teams/a1'), { pingas: 3 })); // 1 -> 3 (+2)
-    await assertSucceeds(updateDoc(doc(adminDb, 'teams/a1'), { pingas: 53 })); // 3 -> 53 (+50)
+    await assertSucceeds(
+      updateDoc(doc(adminDb, 'teams/a1'), {
+        pingas: 3,
+        'drinkTotals.light.quantity': 3,
+        'drinkTotals.light.pingas': 3,
+      })
+    ); // 1 -> 3 (+2)
+    await assertSucceeds(
+      updateDoc(doc(adminDb, 'teams/a1'), {
+        pingas: 53,
+        'drinkTotals.light.quantity': 4,
+        'drinkTotals.light.pingas': 4,
+        'drinkTotals.white-spirit.quantity': 1,
+        'drinkTotals.white-spirit.pingas': 5,
+        'drinkTotals.metro.quantity': 4,
+        'drinkTotals.metro.pingas': 44,
+      })
+    ); // 3 -> 53 (+50)
+
+    await assertFails(
+      updateDoc(doc(adminDb, 'teams/a1'), {
+        pingas: 54,
+        'drinkTotals.light.quantity': 5,
+        'drinkTotals.light.pingas': 10,
+      })
+    ); // score and projection deltas must agree
+    await assertFails(
+      updateDoc(doc(adminDb, 'teams/a1'), {
+        pingas: 54,
+        'drinkTotals.cocktail.quantity': 1,
+        'drinkTotals.cocktail.pingas': 1,
+      })
+    ); // only configured drink IDs may be projected
 
     // Out-of-range increments denied (>50)
     const { db: seedDb } = makeAdminDb('increment-seed');
@@ -121,7 +166,14 @@ describe('Firestore security rules', () => {
     await assertFails(updateDoc(doc(adminDb, 'teams/b1'), { pingas: 51 })); // 0 -> 51 (+51)
 
     // Negative increments denied; totals never negative
-    await setDoc(doc(seedDb, 'teams/c1'), { name: 'C', pingas: 2 });
+    await setDoc(doc(seedDb, 'teams/c1'), { name: 'C', pingas: 0 });
+    await assertSucceeds(
+      updateDoc(doc(seedDb, 'teams/c1'), {
+        pingas: 2,
+        'drinkTotals.light.quantity': 2,
+        'drinkTotals.light.pingas': 2,
+      })
+    );
     await assertFails(updateDoc(doc(adminDb, 'teams/c1'), { pingas: 1 })); // 2 -> 1 (-1)
     await assertFails(updateDoc(doc(adminDb, 'teams/c1'), { pingas: -1 })); // negative total
 

--- a/rules-tests/firestore.rules.test.js
+++ b/rules-tests/firestore.rules.test.js
@@ -111,6 +111,13 @@ describe('Firestore security rules', () => {
         drinkTotals: { cocktail: { quantity: 0, pingas: 0 } },
       })
     );
+    await assertFails(
+      setDoc(doc(adminDb, 'teams/prepopulated-total'), {
+        name: 'Pre-populated total',
+        pingas: 0,
+        drinkTotals: { light: { quantity: 1, pingas: 1 } },
+      })
+    );
 
     // Allowed increments 1..50
     await assertSucceeds(

--- a/rules-tests/firestore.rules.test.js
+++ b/rules-tests/firestore.rules.test.js
@@ -99,6 +99,13 @@ describe('Firestore security rules', () => {
 
     // Metadata-only updates are allowed.
     await assertSucceeds(updateDoc(doc(adminDb, 'teams/a1'), { name: 'Alpha' }));
+    // Legacy teams without a projection cannot add one outside a score update.
+    await assertFails(
+      updateDoc(doc(adminDb, 'teams/a1'), {
+        'drinkTotals.light.quantity': 1,
+        'drinkTotals.light.pingas': 1,
+      })
+    );
 
     // Teams start with no score and no attributed drinks.
     await assertFails(

--- a/src/services/__tests__/leaderboard.test.js
+++ b/src/services/__tests__/leaderboard.test.js
@@ -93,38 +93,6 @@ describe('services/leaderboard', () => {
     expect(cb).toHaveBeenCalledWith([{ id: 'x', name: 'X', pingas: 9 }]);
   });
 
-  test('addPinga validates delta and updates doc with increment', async () => {
-    const { addPinga } = await import('../leaderboard');
-    await addPinga('team1', 3, 'u1');
-    expect(mockDoc).toHaveBeenCalledWith({}, 'teams', 'team1');
-    expect(mockCollection).toHaveBeenCalledWith({}, 'events');
-    expect(mockIncrement).toHaveBeenCalledWith(3);
-    expect(mockWriteBatch).toHaveBeenCalledWith({});
-    expect(mockBatchUpdate).toHaveBeenCalledWith(
-      { col: 'teams', id: 'team1' },
-      { pingas: { __op: 'increment', n: 3 } }
-    );
-    expect(mockBatchSet).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        actorUid: 'u1',
-        delta: 3,
-        teamId: 'team1',
-        ts: 'server-ts',
-        type: 'add-pinga',
-      })
-    );
-    expect(mockBatchCommit).toHaveBeenCalledTimes(1);
-  });
-
-  test('addPinga throws on invalid delta', async () => {
-    const { addPinga } = await import('../leaderboard');
-    await expect(addPinga('team1', 0)).rejects.toThrow('Delta must be an integer between 1 and 50');
-    await expect(addPinga('team1', 51)).rejects.toThrow(
-      'Delta must be an integer between 1 and 50'
-    );
-  });
-
   test.each(['', ' team1', 'team1 ', 'team/1'])(
     'addDrinkPingas rejects invalid team IDs: %j',
     async (teamId) => {

--- a/src/services/leaderboard.js
+++ b/src/services/leaderboard.js
@@ -29,26 +29,6 @@ export function observeLeaderboard(callback) {
   });
 }
 
-export async function addPinga(teamId, delta, _actorUid) {
-  // Enforce service-level guardrails; rules will enforce too.
-  const n = Number(delta);
-  if (!Number.isInteger(n) || n < 1 || n > 50) {
-    throw new Error('Delta must be an integer between 1 and 50');
-  }
-  const ref = doc(db, 'teams', teamId);
-  const eventRef = doc(collection(db, 'events'));
-  const batch = writeBatch(db);
-  batch.update(ref, { pingas: increment(n) });
-  batch.set(eventRef, {
-    ts: serverTimestamp(),
-    actorUid: _actorUid ?? null,
-    type: 'add-pinga',
-    delta: n,
-    teamId,
-  });
-  await batch.commit();
-}
-
 const SAFE_DRINK_ID = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
 function validateTeamId(teamId) {


### PR DESCRIPTION
## Summary
- enforce the fixed drink catalogue and arithmetic in Firestore team score updates
- require every score increment to reconcile with the drinkTotals projection
- document the rules/catalogue coupling and add emulator regression coverage

## Validation
- yarn test:rules
- yarn lint
- yarn typecheck