### PR TITLE
fix: pin preview deploy Node version

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -129,7 +129,8 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
+          # The production base of a release PR can predate .nvmrc.
+          node-version: '22.19.0'
 
       - name: Enable Corepack
         run: corepack enable


### PR DESCRIPTION
## Summary
- pin the trusted preview deploy job to Node 22.19.0
- avoid relying on .nvmrc from an older release PR base revision

## Validation
- yarn prettier --check .github/workflows/pr-preview.yml
- yarn lint
- yarn typecheck

## Root cause
PR #42 preview deployment checked out production as trusted tooling, but that historical commit predates .nvmrc.