### PR TITLE
fix: use trusted default branch for preview tooling

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -120,10 +120,10 @@ jobs:
       FIREBASE_DEFAULT_PROJECT: taca-da-pinga
 
     steps:
-      - name: Checkout trusted base revision
+      - name: Checkout trusted default-branch tooling
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
       - name: Setup Node


### PR DESCRIPTION
## Summary
- install the credentialed preview deploy tooling from the protected default branch
- keep PR output limited to the static preview artifact
- support release PRs whose older production base predates the Yarn 4 toolchain

## Validation
- yarn prettier --check .github/workflows/pr-preview.yml
- yarn lint
- yarn typecheck

## Security
The deploy job never checks out PR code and does not expose the Firebase service account to the PR build job.