### PR TITLE
feat: allow editing team names

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -10,6 +10,13 @@ service cloud.firestore {
       return isSignedIn() && request.auth.token.admin == true;
     }
 
+    function hasValidTeamName(data) {
+      return data.name is string &&
+        data.name.size() >= 1 &&
+        data.name.size() <= 80 &&
+        data.name.matches('.*\\S.*');
+    }
+
     function isDataUrl(s) {
       return s is string && s.matches('^data:image/.*');
     }
@@ -86,7 +93,7 @@ service cloud.firestore {
       allow read: if true;
 
       // Create/update/delete only by admins
-      allow create: if isAdmin() &&
+      allow create: if isAdmin() && hasValidTeamName(request.resource.data) &&
         // New teams begin with no score and an empty (or absent) projection.
         request.resource.data.pingas is int && request.resource.data.pingas == 0 &&
         hasEmptyDrinkTotals(drinkTotals(request.resource.data));
@@ -95,11 +102,13 @@ service cloud.firestore {
         // Metadata-only edits are allowed, but the service-owned drink projection
         // cannot change without a score increment.
         (
+          hasValidTeamName(request.resource.data) &&
           !(request.resource.data.diff(resource.data).affectedKeys().hasAny(['pingas'])) &&
           !(request.resource.data.diff(resource.data).affectedKeys().hasAny(['drinkTotals']))
         ) ||
         // If pingas changes, enforce bounds and positivity, and types
         (
+          hasValidTeamName(request.resource.data) &&
           (request.resource.data.pingas is int) &&
           (resource.data.pingas is int) &&
           request.resource.data.pingas >= 0 &&

--- a/rules-tests/firestore.rules.test.js
+++ b/rules-tests/firestore.rules.test.js
@@ -99,6 +99,8 @@ describe('Firestore security rules', () => {
 
     // Metadata-only updates are allowed.
     await assertSucceeds(updateDoc(doc(adminDb, 'teams/a1'), { name: 'Alpha' }));
+    await assertFails(updateDoc(doc(adminDb, 'teams/a1'), { name: '   ' }));
+    await assertFails(updateDoc(doc(adminDb, 'teams/a1'), { name: 42 }));
     // Legacy teams without a projection cannot add one outside a score update.
     await assertFails(
       updateDoc(doc(adminDb, 'teams/a1'), {

--- a/src/components/ManageTeamsPanel.module.css
+++ b/src/components/ManageTeamsPanel.module.css
@@ -305,14 +305,15 @@
   }
 
   .item {
-    grid-template-columns: minmax(0, 1fr);
-    align-items: stretch;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
     gap: var(--ui-space-xs);
+    min-height: 4rem;
   }
 
   .right {
-    justify-content: space-between;
-    width: 100%;
+    justify-content: flex-end;
+    width: auto;
   }
 
   .editForm {
@@ -322,13 +323,40 @@
   .editActions,
   .actionGroup {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .editActions {
+    grid-column: 1 / -1;
     width: 100%;
   }
 
-  .editActions > button,
-  .actionGroup > button {
+  .editActions > button {
     width: 100%;
     min-height: 3.25rem;
+  }
+
+  .actionGroup {
+    display: flex;
+    gap: var(--ui-space-2xs);
+  }
+
+  .actionGroup > button {
+    width: 2.75rem;
+    min-width: 2.75rem;
+    min-height: 2.75rem;
+    padding: 0;
+  }
+
+  .actionLabel {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 
   .countPill {

--- a/src/components/ManageTeamsPanel.module.css
+++ b/src/components/ManageTeamsPanel.module.css
@@ -153,6 +153,79 @@
   min-width: 0;
 }
 
+.editForm {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--ui-space-sm);
+  width: 100%;
+  min-width: 0;
+}
+
+.editField {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ui-space-2xs);
+  min-width: 0;
+  color: var(--ui-color-text-secondary);
+  font-size: 0.85rem;
+  font-weight: var(--ui-font-weight-bold);
+}
+
+.editField input {
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 2.75rem;
+  padding: 0 var(--ui-space-sm);
+  border: 1px solid var(--ui-color-border-subtle);
+  border-radius: var(--ui-radius-sm);
+  background: var(--ui-color-surface-muted);
+  color: var(--ui-color-text-primary);
+  font: inherit;
+}
+
+.editField input:focus {
+  outline: none;
+  border-color: rgba(34, 197, 94, 0.5);
+  box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.2);
+}
+
+.editActions,
+.actionGroup {
+  display: grid;
+  grid-template-columns: repeat(2, max-content);
+  gap: var(--ui-space-xs);
+  align-items: end;
+}
+
+.saveBtn,
+.cancelBtn {
+  min-height: 2.75rem;
+  padding: 0 var(--ui-space-md);
+  border: 1px solid transparent;
+  border-radius: var(--ui-radius-full);
+  cursor: pointer;
+  font: inherit;
+  font-weight: var(--ui-font-weight-extrabold);
+}
+
+.saveBtn {
+  background: var(--ui-color-accent-soft);
+  border-color: rgba(34, 197, 94, 0.35);
+  color: var(--ui-color-accent);
+}
+
+.cancelBtn {
+  background: var(--ui-color-surface-muted);
+  border-color: var(--ui-color-border-subtle);
+  color: var(--ui-color-text-primary);
+}
+
+.saveBtn:disabled,
+.cancelBtn:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
 .dot {
   width: 0.5rem;
   height: 0.5rem;
@@ -189,27 +262,6 @@
   min-width: 2.5rem;
   min-height: 1.75rem;
   text-align: center;
-}
-
-.deleteBtn {
-  background: var(--ui-color-danger-soft);
-  color: var(--ui-color-danger);
-  border: 1px solid rgba(239, 68, 68, 0.6);
-  padding: 0.4rem 0.85rem;
-  border-radius: var(--ui-radius-full);
-  cursor: pointer;
-  font-size: 0.9rem;
-  font-weight: var(--ui-font-weight-semibold);
-  transition:
-    background var(--ui-transition-base),
-    color var(--ui-transition-base),
-    transform var(--ui-transition-fast);
-}
-
-.deleteBtn:hover {
-  background: var(--ui-color-danger);
-  color: var(--ui-color-text-inverted);
-  transform: translateY(-1px);
 }
 
 .visuallyHidden {
@@ -261,6 +313,22 @@
   .right {
     justify-content: space-between;
     width: 100%;
+  }
+
+  .editForm {
+    grid-template-columns: 1fr;
+  }
+
+  .editActions,
+  .actionGroup {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    width: 100%;
+  }
+
+  .editActions > button,
+  .actionGroup > button {
+    width: 100%;
+    min-height: 3.25rem;
   }
 
   .countPill {

--- a/src/components/ManageTeamsPanel.tsx
+++ b/src/components/ManageTeamsPanel.tsx
@@ -38,13 +38,6 @@ export default function ManageTeamsPanel() {
     return unsubscribe;
   }, []);
 
-  useEffect(() => {
-    if (editingTeamId && !teams.some((team) => team.id === editingTeamId)) {
-      setEditingTeamId(null);
-      setEditName('');
-    }
-  }, [editingTeamId, teams]);
-
   const createTeam = async () => {
     const nameTrim = newName.trim();
     if (!nameTrim) {
@@ -138,6 +131,13 @@ export default function ManageTeamsPanel() {
     () => teams.filter((team) => team.name.toLowerCase().includes(filter.toLowerCase())),
     [filter, teams]
   );
+
+  useEffect(() => {
+    if (editingTeamId && !visible.some((team) => team.id === editingTeamId)) {
+      setEditingTeamId(null);
+      setEditName('');
+    }
+  }, [editingTeamId, visible]);
 
   return (
     <div className={styles.panel}>

--- a/src/components/ManageTeamsPanel.tsx
+++ b/src/components/ManageTeamsPanel.tsx
@@ -3,6 +3,7 @@ import {
   observeTeamsOrderedByName,
   createTeamIfNotExists,
   deleteTeam,
+  TEAM_NAME_MAX_LENGTH,
   updateTeamName,
 } from '../services/teams';
 import { toast } from 'react-toastify';
@@ -43,6 +44,10 @@ export default function ManageTeamsPanel() {
       toast.error('Nome não pode estar vazio');
       return;
     }
+    if (nameTrim.length > TEAM_NAME_MAX_LENGTH) {
+      toast.error(`O nome não pode ter mais de ${TEAM_NAME_MAX_LENGTH} caracteres`);
+      return;
+    }
     try {
       await createTeamIfNotExists(nameTrim);
     } catch (error) {
@@ -53,7 +58,10 @@ export default function ManageTeamsPanel() {
           return;
         }
       }
-      throw error;
+
+      const message = error instanceof Error ? error.message : 'Não foi possível criar a equipa';
+      toast.error(message);
+      return;
     }
     toast.success('Equipa criada');
     setNewName('');
@@ -90,6 +98,10 @@ export default function ManageTeamsPanel() {
     const name = editName.trim();
     if (!name) {
       toast.error('Nome não pode estar vazio');
+      return;
+    }
+    if (name.length > TEAM_NAME_MAX_LENGTH) {
+      toast.error(`O nome não pode ter mais de ${TEAM_NAME_MAX_LENGTH} caracteres`);
       return;
     }
 

--- a/src/components/ManageTeamsPanel.tsx
+++ b/src/components/ManageTeamsPanel.tsx
@@ -38,6 +38,13 @@ export default function ManageTeamsPanel() {
     return unsubscribe;
   }, []);
 
+  useEffect(() => {
+    if (editingTeamId && !teams.some((team) => team.id === editingTeamId)) {
+      setEditingTeamId(null);
+      setEditName('');
+    }
+  }, [editingTeamId, teams]);
+
   const createTeam = async () => {
     const nameTrim = newName.trim();
     if (!nameTrim) {

--- a/src/components/ManageTeamsPanel.tsx
+++ b/src/components/ManageTeamsPanel.tsx
@@ -219,7 +219,7 @@ export default function ManageTeamsPanel() {
                       onClick={() => startEditingTeam(team)}
                       disabled={Boolean(editingTeamId) || busyTeamId === team.id}
                     >
-                      Editar
+                      <span className={styles.actionLabel}>Editar</span>
                     </AdminActionButton>
                     <AdminActionButton
                       icon={IconTrash}
@@ -227,7 +227,7 @@ export default function ManageTeamsPanel() {
                       onClick={() => setToDelete(team)}
                       disabled={Boolean(editingTeamId) || busyTeamId === team.id}
                     >
-                      Eliminar
+                      <span className={styles.actionLabel}>Eliminar</span>
                     </AdminActionButton>
                   </div>
                 )}

--- a/src/components/ManageTeamsPanel.tsx
+++ b/src/components/ManageTeamsPanel.tsx
@@ -1,6 +1,13 @@
 import { useEffect, useMemo, useState } from 'react';
-import { observeTeamsOrderedByName, createTeamIfNotExists, deleteTeam } from '../services/teams';
+import {
+  observeTeamsOrderedByName,
+  createTeamIfNotExists,
+  deleteTeam,
+  updateTeamName,
+} from '../services/teams';
 import { toast } from 'react-toastify';
+import { IconPencil, IconTrash } from '@tabler/icons-react';
+import { AdminActionButton } from '../ui/components/AdminActionButton';
 import styles from './ManageTeamsPanel.module.css';
 import ConfirmModal from './ConfirmModal';
 
@@ -15,6 +22,9 @@ export default function ManageTeamsPanel() {
   const [newName, setNewName] = useState('');
   const [filter, setFilter] = useState('');
   const [toDelete, setToDelete] = useState<Team | null>(null);
+  const [editingTeamId, setEditingTeamId] = useState<string | null>(null);
+  const [editName, setEditName] = useState('');
+  const [busyTeamId, setBusyTeamId] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [isLoaded, setIsLoaded] = useState(false);
 
@@ -66,6 +76,45 @@ export default function ManageTeamsPanel() {
     }
   };
 
+  const startEditingTeam = (team: Team) => {
+    setEditingTeamId(team.id);
+    setEditName(team.name);
+  };
+
+  const cancelEditingTeam = () => {
+    setEditingTeamId(null);
+    setEditName('');
+  };
+
+  const saveTeamName = async (team: Team) => {
+    const name = editName.trim();
+    if (!name) {
+      toast.error('Nome não pode estar vazio');
+      return;
+    }
+
+    setBusyTeamId(team.id);
+    try {
+      await updateTeamName(team.id, name);
+      toast.success('Equipa atualizada');
+      cancelEditingTeam();
+    } catch (error) {
+      if (error && typeof error === 'object' && 'code' in error) {
+        const { code } = error as { code?: string };
+        if (code === 'already-exists') {
+          toast.error('Equipa já existe');
+          return;
+        }
+      }
+
+      const message =
+        error instanceof Error ? error.message : 'Não foi possível atualizar a equipa';
+      toast.error(message);
+    } finally {
+      setBusyTeamId(null);
+    }
+  };
+
   const visible = useMemo(
     () => teams.filter((team) => team.name.toLowerCase().includes(filter.toLowerCase())),
     [filter, teams]
@@ -83,7 +132,12 @@ export default function ManageTeamsPanel() {
           onChange={(e) => setNewName(e.target.value)}
           className={styles.input}
         />
-        <button type="button" onClick={createTeam} className={styles.createBtn}>
+        <button
+          type="button"
+          onClick={createTeam}
+          className={styles.createBtn}
+          disabled={Boolean(editingTeamId) || Boolean(busyTeamId)}
+        >
           Criar
         </button>
       </div>
@@ -116,18 +170,67 @@ export default function ManageTeamsPanel() {
             <li key={team.id} className={styles.item}>
               <div className={styles.left}>
                 <span className={styles.dot} aria-hidden />
-                <span className={styles.teamName}>{team.name}</span>
+                {editingTeamId === team.id ? (
+                  <form
+                    className={styles.editForm}
+                    onSubmit={(event) => {
+                      event.preventDefault();
+                      void saveTeamName(team);
+                    }}
+                  >
+                    <label className={styles.editField}>
+                      <span>Nome da equipa</span>
+                      <input
+                        type="text"
+                        value={editName}
+                        onChange={(event) => setEditName(event.target.value)}
+                        disabled={busyTeamId === team.id}
+                        autoFocus
+                      />
+                    </label>
+                    <div className={styles.editActions}>
+                      <button
+                        type="submit"
+                        className={styles.saveBtn}
+                        disabled={busyTeamId === team.id}
+                      >
+                        Guardar
+                      </button>
+                      <button
+                        type="button"
+                        className={styles.cancelBtn}
+                        onClick={cancelEditingTeam}
+                        disabled={busyTeamId === team.id}
+                      >
+                        Cancelar
+                      </button>
+                    </div>
+                  </form>
+                ) : (
+                  <span className={styles.teamName}>{team.name}</span>
+                )}
               </div>
               <div className={styles.right}>
                 <span className={styles.countPill}>{team.pingas}</span>
-                <button
-                  type="button"
-                  onClick={() => setToDelete(team)}
-                  className={styles.deleteBtn}
-                  aria-label={`Eliminar ${team.name}`}
-                >
-                  Eliminar
-                </button>
+                {editingTeamId === team.id ? null : (
+                  <div className={styles.actionGroup}>
+                    <AdminActionButton
+                      icon={IconPencil}
+                      onClick={() => startEditingTeam(team)}
+                      disabled={Boolean(editingTeamId) || busyTeamId === team.id}
+                    >
+                      Editar
+                    </AdminActionButton>
+                    <AdminActionButton
+                      icon={IconTrash}
+                      tone="danger"
+                      onClick={() => setToDelete(team)}
+                      disabled={Boolean(editingTeamId) || busyTeamId === team.id}
+                    >
+                      Eliminar
+                    </AdminActionButton>
+                  </div>
+                )}
               </div>
             </li>
           ))}

--- a/src/components/SponsorsAdminPanel.module.css
+++ b/src/components/SponsorsAdminPanel.module.css
@@ -409,6 +409,18 @@
   gap: var(--ui-space-xs);
 }
 
+.actionButton {
+  gap: var(--ui-space-xs);
+  min-width: 0;
+  padding: 0 var(--ui-space-sm);
+}
+
+.actionButton svg {
+  width: 1.15rem;
+  height: 1.15rem;
+  stroke-width: 2;
+}
+
 @media (max-width: 75rem) {
   .form {
     grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/src/components/SponsorsAdminPanel.module.css
+++ b/src/components/SponsorsAdminPanel.module.css
@@ -409,18 +409,6 @@
   gap: var(--ui-space-xs);
 }
 
-.actionButton {
-  gap: var(--ui-space-xs);
-  min-width: 0;
-  padding: 0 var(--ui-space-sm);
-}
-
-.actionButton svg {
-  width: 1.15rem;
-  height: 1.15rem;
-  stroke-width: 2;
-}
-
 @media (max-width: 75rem) {
   .form {
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -450,7 +438,8 @@
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .actionButton {
+  .adminActionButton,
+  .siteActionGroup > button {
     width: 100%;
   }
 }
@@ -494,7 +483,8 @@
     min-height: 3.25rem;
   }
 
-  .actionButton {
+  .adminActionButton,
+  .siteActionGroup > button {
     min-height: 3.25rem;
     padding: 0 var(--ui-space-xs);
   }

--- a/src/components/SponsorsAdminPanel.tsx
+++ b/src/components/SponsorsAdminPanel.tsx
@@ -41,6 +41,7 @@ import {
 } from '../services/sponsors.service';
 import ConfirmModal from './ConfirmModal';
 import { toast } from 'react-toastify';
+import { AdminActionButton } from '../ui/components/AdminActionButton';
 import styles from './SponsorsAdminPanel.module.css';
 
 type SponsorFormState = {
@@ -532,15 +533,14 @@ export default function SponsorsAdminPanel() {
                             </>
                           ) : (
                             <>
-                              <button
-                                type="button"
-                                className={`${styles.neutralButton} ${styles.actionButton}`}
+                              <AdminActionButton
+                                className={styles.adminActionButton}
                                 onClick={() => startEditingSponsor(sponsor)}
                                 disabled={isBusy}
+                                icon={IconPencil}
                               >
-                                <IconPencil aria-hidden="true" />
                                 Editar
-                              </button>
+                              </AdminActionButton>
                               <div className={styles.siteActionGroup}>
                                 <button
                                   type="button"
@@ -557,17 +557,17 @@ export default function SponsorsAdminPanel() {
                                   )}
                                   {sponsor.active ? 'Ocultar' : 'Mostrar'}
                                 </button>
-                                <button
-                                  type="button"
-                                  className={`${styles.dangerButton} ${styles.actionButton}`}
+                                <AdminActionButton
+                                  className={styles.adminActionButton}
                                   onClick={() => {
                                     setSponsorToDelete(sponsor);
                                   }}
                                   disabled={isBusy}
+                                  icon={IconTrash}
+                                  tone="danger"
                                 >
-                                  <IconTrash aria-hidden="true" />
                                   Eliminar
-                                </button>
+                                </AdminActionButton>
                               </div>
                             </>
                           )}

--- a/src/components/__tests__/ManageTeamsPanel.test.tsx
+++ b/src/components/__tests__/ManageTeamsPanel.test.tsx
@@ -8,6 +8,7 @@ vi.mock('../../services/teams', () => ({
   createTeamIfNotExists: vi.fn(),
   deleteTeam: vi.fn(),
   observeTeamsOrderedByName: vi.fn(),
+  TEAM_NAME_MAX_LENGTH: 80,
   updateTeamName: vi.fn(),
 }));
 
@@ -89,5 +90,15 @@ describe('ManageTeamsPanel editing', () => {
       expect(toastMock.error).toHaveBeenCalledWith('Equipa já existe');
     });
     expect(screen.getByRole('textbox', { name: 'Nome da equipa' })).toBeInTheDocument();
+  });
+
+  test('rejects overly long names before calling the team service', async () => {
+    render(<ManageTeamsPanel />);
+
+    const newTeamInput = screen.getByRole('textbox', { name: 'Nova equipa' });
+    fireEvent.change(newTeamInput, { target: { value: 'A'.repeat(81) } });
+    fireEvent.click(screen.getByRole('button', { name: 'Criar' }));
+
+    expect(toastMock.error).toHaveBeenCalledWith('O nome não pode ter mais de 80 caracteres');
   });
 });

--- a/src/components/__tests__/ManageTeamsPanel.test.tsx
+++ b/src/components/__tests__/ManageTeamsPanel.test.tsx
@@ -1,0 +1,93 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import ManageTeamsPanel from '../ManageTeamsPanel';
+import { toast } from 'react-toastify';
+import { observeTeamsOrderedByName, updateTeamName } from '../../services/teams';
+
+vi.mock('../../services/teams', () => ({
+  createTeamIfNotExists: vi.fn(),
+  deleteTeam: vi.fn(),
+  observeTeamsOrderedByName: vi.fn(),
+  updateTeamName: vi.fn(),
+}));
+
+vi.mock('react-toastify', () => ({
+  toast: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+}));
+
+const teams = [
+  { id: 'team-1', name: 'Equipa Alfa', pingas: 12 },
+  { id: 'team-2', name: 'Equipa Beta', pingas: 4 },
+];
+
+const observeTeamsMock = vi.mocked(observeTeamsOrderedByName);
+const updateTeamNameMock = vi.mocked(updateTeamName);
+const toastMock = vi.mocked(toast);
+
+describe('ManageTeamsPanel editing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    observeTeamsMock.mockImplementation((callback) => {
+      callback(teams);
+      return vi.fn();
+    });
+    updateTeamNameMock.mockResolvedValue(undefined);
+  });
+
+  test('edits a team name and saves it from the inline form', async () => {
+    render(<ManageTeamsPanel />);
+
+    fireEvent.click(
+      await screen.findAllByRole('button', { name: 'Editar' }).then((buttons) => buttons[0])
+    );
+    const input = screen.getByRole('textbox', { name: 'Nome da equipa' });
+    expect(input).toHaveFocus();
+    fireEvent.change(input, { target: { value: 'Equipa Campeã' } });
+    fireEvent.submit(input.closest('form')!);
+
+    await waitFor(() => {
+      expect(updateTeamNameMock).toHaveBeenCalledWith('team-1', 'Equipa Campeã');
+    });
+    expect(toastMock.success).toHaveBeenCalledWith('Equipa atualizada');
+    expect(screen.queryByRole('textbox', { name: 'Nome da equipa' })).not.toBeInTheDocument();
+  });
+
+  test('cancels editing without saving', async () => {
+    render(<ManageTeamsPanel />);
+
+    fireEvent.click(
+      await screen.findAllByRole('button', { name: 'Editar' }).then((buttons) => buttons[0])
+    );
+    fireEvent.change(screen.getByRole('textbox', { name: 'Nome da equipa' }), {
+      target: { value: 'Nome temporário' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Cancelar' }));
+
+    expect(updateTeamNameMock).not.toHaveBeenCalled();
+    expect(screen.getByText('Equipa Alfa')).toBeInTheDocument();
+  });
+
+  test('keeps the editor open and reports duplicate and empty names', async () => {
+    render(<ManageTeamsPanel />);
+    fireEvent.click(
+      await screen.findAllByRole('button', { name: 'Editar' }).then((buttons) => buttons[0])
+    );
+    const input = screen.getByRole('textbox', { name: 'Nome da equipa' });
+
+    fireEvent.change(input, { target: { value: '   ' } });
+    fireEvent.submit(input.closest('form')!);
+    expect(toastMock.error).toHaveBeenCalledWith('Nome não pode estar vazio');
+
+    const duplicateError = Object.assign(new Error('Team already exists'), {
+      code: 'already-exists',
+    });
+    updateTeamNameMock.mockRejectedValueOnce(duplicateError);
+    fireEvent.change(input, { target: { value: 'Equipa Beta' } });
+    fireEvent.submit(input.closest('form')!);
+
+    await waitFor(() => {
+      expect(toastMock.error).toHaveBeenCalledWith('Equipa já existe');
+    });
+    expect(screen.getByRole('textbox', { name: 'Nome da equipa' })).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/ManageTeamsPanel.test.tsx
+++ b/src/components/__tests__/ManageTeamsPanel.test.tsx
@@ -119,4 +119,20 @@ describe('ManageTeamsPanel editing', () => {
     expect(screen.getByRole('button', { name: 'Criar' })).toBeEnabled();
     expect(screen.getByRole('button', { name: 'Editar' })).toBeEnabled();
   });
+
+  test('clears the edit lock when filtering hides the edited team', async () => {
+    render(<ManageTeamsPanel />);
+    fireEvent.click(
+      await screen.findAllByRole('button', { name: 'Editar' }).then((buttons) => buttons[0])
+    );
+    expect(screen.getByRole('textbox', { name: 'Nome da equipa' })).toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Filtrar equipas' }), {
+      target: { value: 'Beta' },
+    });
+
+    expect(screen.queryByRole('textbox', { name: 'Nome da equipa' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Criar' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Editar' })).toBeEnabled();
+  });
 });

--- a/src/components/__tests__/ManageTeamsPanel.test.tsx
+++ b/src/components/__tests__/ManageTeamsPanel.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import ManageTeamsPanel from '../ManageTeamsPanel';
 import { toast } from 'react-toastify';
@@ -24,11 +24,13 @@ const teams = [
 const observeTeamsMock = vi.mocked(observeTeamsOrderedByName);
 const updateTeamNameMock = vi.mocked(updateTeamName);
 const toastMock = vi.mocked(toast);
+let observedTeamsCallback: ((nextTeams: typeof teams) => void) | undefined;
 
 describe('ManageTeamsPanel editing', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     observeTeamsMock.mockImplementation((callback) => {
+      observedTeamsCallback = callback;
       callback(teams);
       return vi.fn();
     });
@@ -100,5 +102,21 @@ describe('ManageTeamsPanel editing', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Criar' }));
 
     expect(toastMock.error).toHaveBeenCalledWith('O nome não pode ter mais de 80 caracteres');
+  });
+
+  test('clears the edit lock when the edited team is removed remotely', async () => {
+    render(<ManageTeamsPanel />);
+    fireEvent.click(
+      await screen.findAllByRole('button', { name: 'Editar' }).then((buttons) => buttons[0])
+    );
+    expect(screen.getByRole('textbox', { name: 'Nome da equipa' })).toBeInTheDocument();
+
+    act(() => {
+      observedTeamsCallback?.([teams[1]]);
+    });
+
+    expect(screen.queryByRole('textbox', { name: 'Nome da equipa' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Criar' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Editar' })).toBeEnabled();
   });
 });

--- a/src/services/__tests__/teams.test.js
+++ b/src/services/__tests__/teams.test.js
@@ -4,22 +4,22 @@ const mockCollection = vi.fn();
 const mockQuery = vi.fn();
 const mockOrderBy = vi.fn((field, dir) => ({ field, dir }));
 const mockOnSnapshot = vi.fn();
-const mockWhere = vi.fn();
 const mockGetDocs = vi.fn();
 const mockAddDoc = vi.fn();
 const mockDoc = vi.fn((db, col, id) => ({ col, id }));
 const mockDeleteDoc = vi.fn();
+const mockUpdateDoc = vi.fn();
 
 vi.mock('firebase/firestore', () => ({
   collection: (...args) => mockCollection(...args),
   query: (...args) => mockQuery(...args),
   orderBy: (...args) => mockOrderBy(...args),
   onSnapshot: (...args) => mockOnSnapshot(...args),
-  where: (...args) => mockWhere(...args),
   getDocs: (...args) => mockGetDocs(...args),
   addDoc: (...args) => mockAddDoc(...args),
   doc: (...args) => mockDoc(...args),
   deleteDoc: (...args) => mockDeleteDoc(...args),
+  updateDoc: (...args) => mockUpdateDoc(...args),
 }));
 
 describe('services/teams', () => {
@@ -43,7 +43,7 @@ describe('services/teams', () => {
 
   test('createTeamIfNotExists adds when not present', async () => {
     const { createTeamIfNotExists } = await import('../teams');
-    mockGetDocs.mockResolvedValue({ empty: true, docs: [] });
+    mockGetDocs.mockResolvedValue({ docs: [] });
     await createTeamIfNotExists('New Team');
     expect(mockAddDoc).toHaveBeenCalledWith(undefined, {
       name: 'New Team',
@@ -52,10 +52,36 @@ describe('services/teams', () => {
     });
   });
 
-  test('createTeamIfNotExists throws when already exists', async () => {
+  test('createTeamIfNotExists rejects names that differ only by letter case', async () => {
     const { createTeamIfNotExists } = await import('../teams');
-    mockGetDocs.mockResolvedValue({ empty: false, docs: [{}] });
-    await expect(createTeamIfNotExists('Existing')).rejects.toThrow('Team already exists');
+    mockGetDocs.mockResolvedValue({
+      docs: [{ id: 'existing', data: () => ({ name: 'Equipa Pinga' }) }],
+    });
+    await expect(createTeamIfNotExists(' equipa pinga ')).rejects.toThrow('Team already exists');
+  });
+
+  test('updateTeamName validates, excludes the current team, and updates only the name', async () => {
+    const { updateTeamName } = await import('../teams');
+    mockGetDocs.mockResolvedValue({
+      docs: [{ id: 'tid', data: () => ({ name: 'Equipa Antiga' }) }],
+    });
+
+    await updateTeamName('tid', ' Equipa Nova ');
+
+    expect(mockUpdateDoc).toHaveBeenCalledWith(
+      { col: 'teams', id: 'tid' },
+      { name: 'Equipa Nova' }
+    );
+  });
+
+  test('updateTeamName rejects an empty or duplicate name', async () => {
+    const { updateTeamName } = await import('../teams');
+    await expect(updateTeamName('tid', '   ')).rejects.toThrow('Name is required');
+
+    mockGetDocs.mockResolvedValue({
+      docs: [{ id: 'other', data: () => ({ name: 'Equipa Pinga' }) }],
+    });
+    await expect(updateTeamName('tid', 'equipa pinga')).rejects.toThrow('Team already exists');
   });
 
   test('deleteTeam deletes by id', async () => {

--- a/src/services/__tests__/teams.test.js
+++ b/src/services/__tests__/teams.test.js
@@ -60,6 +60,17 @@ describe('services/teams', () => {
     await expect(createTeamIfNotExists(' equipa pinga ')).rejects.toThrow('Team already exists');
   });
 
+  test('rejects team names longer than the Firestore rule allows', async () => {
+    const { createTeamIfNotExists, updateTeamName, TEAM_NAME_MAX_LENGTH } = await import(
+      '../teams'
+    );
+    const longName = 'A'.repeat(TEAM_NAME_MAX_LENGTH + 1);
+
+    await expect(createTeamIfNotExists(longName)).rejects.toMatchObject({ code: 'name-too-long' });
+    await expect(updateTeamName('tid', longName)).rejects.toMatchObject({ code: 'name-too-long' });
+    expect(mockGetDocs).not.toHaveBeenCalled();
+  });
+
   test('updateTeamName validates, excludes the current team, and updates only the name', async () => {
     const { updateTeamName } = await import('../teams');
     mockGetDocs.mockResolvedValue({

--- a/src/services/teams.js
+++ b/src/services/teams.js
@@ -4,12 +4,38 @@ import {
   query,
   orderBy,
   onSnapshot,
-  where,
   getDocs,
   addDoc,
   doc,
   deleteDoc,
+  updateDoc,
 } from 'firebase/firestore';
+
+function normalizeTeamName(name) {
+  return String(name || '').trim();
+}
+
+function getTeamNameKey(name) {
+  return normalizeTeamName(name).toLocaleLowerCase('pt-PT');
+}
+
+async function assertTeamNameAvailable(name, excludedTeamId) {
+  const teamsSnapshot = await getDocs(collection(db, 'teams'));
+  const nameKey = getTeamNameKey(name);
+  const hasDuplicate = teamsSnapshot.docs.some((team) => {
+    if (team.id === excludedTeamId) {
+      return false;
+    }
+
+    return getTeamNameKey(team.data().name) === nameKey;
+  });
+
+  if (hasDuplicate) {
+    const err = new Error('Team already exists');
+    err.code = 'already-exists';
+    throw err;
+  }
+}
 
 export function observeTeamsOrderedByName(callback) {
   const q = query(collection(db, 'teams'), orderBy('name'));
@@ -20,16 +46,19 @@ export function observeTeamsOrderedByName(callback) {
 }
 
 export async function createTeamIfNotExists(name) {
-  const nameTrim = String(name || '').trim();
+  const nameTrim = normalizeTeamName(name);
   if (!nameTrim) throw new Error('Name is required');
-  const q = query(collection(db, 'teams'), where('name', '==', nameTrim));
-  const snap = await getDocs(q);
-  if (!snap.empty) {
-    const err = new Error('Team already exists');
-    err.code = 'already-exists';
-    throw err;
-  }
+
+  await assertTeamNameAvailable(nameTrim);
   await addDoc(collection(db, 'teams'), { name: nameTrim, pingas: 0, drinkTotals: {} });
+}
+
+export async function updateTeamName(teamId, name) {
+  const nameTrim = normalizeTeamName(name);
+  if (!nameTrim) throw new Error('Name is required');
+
+  await assertTeamNameAvailable(nameTrim, teamId);
+  await updateDoc(doc(db, 'teams', teamId), { name: nameTrim });
 }
 
 export async function deleteTeam(teamId) {

--- a/src/services/teams.js
+++ b/src/services/teams.js
@@ -11,8 +11,27 @@ import {
   updateDoc,
 } from 'firebase/firestore';
 
+export const TEAM_NAME_MAX_LENGTH = 80;
+
 function normalizeTeamName(name) {
   return String(name || '').trim();
+}
+
+function validateTeamName(name) {
+  const nameTrim = normalizeTeamName(name);
+  if (!nameTrim) {
+    const err = new Error('Name is required');
+    err.code = 'invalid-name';
+    throw err;
+  }
+
+  if (nameTrim.length > TEAM_NAME_MAX_LENGTH) {
+    const err = new Error(`Team name must be ${TEAM_NAME_MAX_LENGTH} characters or fewer`);
+    err.code = 'name-too-long';
+    throw err;
+  }
+
+  return nameTrim;
 }
 
 function getTeamNameKey(name) {
@@ -46,16 +65,14 @@ export function observeTeamsOrderedByName(callback) {
 }
 
 export async function createTeamIfNotExists(name) {
-  const nameTrim = normalizeTeamName(name);
-  if (!nameTrim) throw new Error('Name is required');
+  const nameTrim = validateTeamName(name);
 
   await assertTeamNameAvailable(nameTrim);
   await addDoc(collection(db, 'teams'), { name: nameTrim, pingas: 0, drinkTotals: {} });
 }
 
 export async function updateTeamName(teamId, name) {
-  const nameTrim = normalizeTeamName(name);
-  if (!nameTrim) throw new Error('Name is required');
+  const nameTrim = validateTeamName(name);
 
   await assertTeamNameAvailable(nameTrim, teamId);
   await updateDoc(doc(db, 'teams', teamId), { name: nameTrim });

--- a/src/ui/components/AdminActionButton.module.css
+++ b/src/ui/components/AdminActionButton.module.css
@@ -1,0 +1,16 @@
+.root {
+  min-width: 0;
+  padding: 0 var(--ui-space-sm);
+}
+
+.neutral {
+  background: var(--ui-color-surface-muted);
+  border-color: var(--ui-color-border-subtle);
+  color: var(--ui-color-text-primary);
+}
+
+.icon {
+  width: 1.15rem;
+  height: 1.15rem;
+  stroke-width: 2;
+}

--- a/src/ui/components/AdminActionButton.tsx
+++ b/src/ui/components/AdminActionButton.tsx
@@ -1,0 +1,38 @@
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+import type { TablerIcon } from '@tabler/icons-react';
+import { Button } from './Button';
+import styles from './AdminActionButton.module.css';
+import { mergeClasses } from './utils';
+
+type AdminActionTone = 'neutral' | 'danger';
+
+export type AdminActionButtonProps = Omit<ComponentPropsWithoutRef<'button'>, 'children'> & {
+  children: ReactNode;
+  icon: TablerIcon;
+  tone?: AdminActionTone;
+};
+
+/** A compact, labelled action for rows in admin lists. */
+export function AdminActionButton({
+  children,
+  className,
+  icon: Icon,
+  tone = 'neutral',
+  ...props
+}: AdminActionButtonProps) {
+  return (
+    <Button
+      {...props}
+      variant={tone === 'danger' ? 'danger' : 'ghost'}
+      size="md"
+      className={mergeClasses(
+        styles.root,
+        tone === 'neutral' ? styles.neutral : undefined,
+        className
+      )}
+    >
+      <Icon className={styles.icon} aria-hidden="true" />
+      {children}
+    </Button>
+  );
+}

--- a/src/ui/components/index.ts
+++ b/src/ui/components/index.ts
@@ -2,6 +2,7 @@ export * from './Page';
 export * from './Section';
 export * from './Card';
 export * from './Button';
+export * from './AdminActionButton';
 export * from './Grid';
 export * from './Stack';
 export * from './Text';


### PR DESCRIPTION
## Summary

- add inline editing for team names in the admin list, with responsive save/cancel actions
- make team-name uniqueness case-insensitive for both creation and rename
- reuse shared Edit/Delete action controls across teams and sponsors
- validate team names in Firestore rules

## Validation

- `yarn test:ci`
- `yarn test:rules`
- `yarn lint`
- `yarn typecheck`
- `yarn build`

## Notes

- Team name updates preserve existing score and drink totals.