### PR TITLE
fix: scope manual hosting deploy

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -6,7 +6,7 @@ set -e
 echo "🛠️ Building app (Vite)..."
 yarn build
 
-echo "🚀 Deploying to Firebase Hosting (dist)..."
-firebase deploy --only hosting
+echo "🚀 Deploying to production Firebase Hosting (dist)..."
+firebase deploy --only hosting:taca-da-pinga
 
 echo "✅ Deploy complete!"

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -24,6 +24,11 @@ The `Deploy Production` workflow runs automatically after a merge to
 deploys the `taca-da-pinga` Firebase Hosting site. Manual workflow runs are
 allowed only when the selected ref is `production`.
 
+For a manual local production deployment, `./deploy.sh` builds the app and
+deploys only `hosting:taca-da-pinga`; it does not deploy the `develop` Hosting
+target. Confirm that the active Firebase credentials and project are the
+intended production ones before running it.
+
 Configure the GitHub **production** environment with the `PRODUCTION_*` secrets
 listed in [CONFIG.md](CONFIG.md#github-secrets). The service account needs
 Firebase Hosting Admin, Firebase Rules Admin, and Cloud Datastore Index Admin


### PR DESCRIPTION
## Summary

Scopes the local manual deployment script to the production Firebase Hosting site.

## Why

With both production and develop Hosting entries in firebase.json, the unscoped hosting deploy command could publish the same build to both sites.

## Changes

- Deploy only hosting:taca-da-pinga from deploy.sh
- Document the manual production deployment scope and credential requirement

## Validation

- bash -n deploy.sh
- yarn lint
- yarn build