### PR TITLE
docs: clarify manual production build env

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -26,8 +26,12 @@ allowed only when the selected ref is `production`.
 
 For a manual local production deployment, `./deploy.sh` builds the app and
 deploys only `hosting:taca-da-pinga`; it does not deploy the `develop` Hosting
-target. Confirm that the active Firebase credentials and project are the
-intended production ones before running it.
+target. Before running it, load the production `VITE_FIREBASE_*` values (for
+example, from an uncommitted `.env.production.local`) and confirm that
+`VITE_FIREBASE_PROJECT_ID` is the production project. Vite embeds these values
+in the bundle during `yarn build`; Firebase CLI credentials alone do not change
+the project's client configuration. Also confirm that the active Firebase CLI
+credentials and project are the intended production ones.
 
 Configure the GitHub **production** environment with the `PRODUCTION_*` secrets
 listed in [CONFIG.md](CONFIG.md#github-secrets). The service account needs


### PR DESCRIPTION
## Summary

Documents the production client-environment requirement for manual local deployments.

## Why

The manual deployment script builds before it deploys. Vite embeds VITE_FIREBASE values in that bundle, so Firebase CLI production credentials alone cannot prevent a develop-configured client from being published to production.

## Validation

- yarn lint
- git diff --check