### PR TITLE
feat: promote leaderboard gaps to production

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A real-time tournament leaderboard for tracking drinks as pingas.
 ## What it does
 
 - Shows a live public leaderboard.
+- Shows the top-five gap to the team immediately above in leaderboard and TV modes.
 - Lets authorised administrators score drinks, manage teams, sponsors and branding.
 - Provides a dedicated display mode for a TV or shared screen.
 - Runs on React, Firebase and Vite, with an installable PWA shell.

--- a/src/components/LeaderboardRow.module.css
+++ b/src/components/LeaderboardRow.module.css
@@ -15,7 +15,7 @@
   background: var(--ui-color-surface);
   border: 1px solid var(--ui-color-border-subtle);
   box-shadow: none;
-  overflow: hidden;
+  overflow: visible;
   isolation: isolate;
   transition: border-color var(--ui-transition-base);
 }
@@ -27,6 +27,39 @@
   width: 0.25rem;
   background: var(--row-accent, var(--ui-color-accent));
   z-index: 0;
+  border-radius: var(--ui-radius-sm) 0 0 var(--ui-radius-sm);
+}
+
+.root::after {
+  content: '';
+  position: absolute;
+  left: calc(100% + (var(--leaderboard-gap-gutter, 4rem) / 2));
+  top: 0;
+  bottom: 0;
+  width: 0.125rem;
+  transform: translateX(-50%);
+  background: rgba(148, 163, 184, 0.52);
+  pointer-events: none;
+  z-index: 0;
+  display: none;
+}
+
+.root[data-gap-rail='start']::after {
+  display: block;
+  top: 50%;
+  bottom: calc(-1 * var(--leaderboard-row-gap, 0.75rem) / 2);
+}
+
+.root[data-gap-rail='middle']::after {
+  display: block;
+  top: calc(-1 * var(--leaderboard-row-gap, 0.75rem) / 2);
+  bottom: calc(-1 * var(--leaderboard-row-gap, 0.75rem) / 2);
+}
+
+.root[data-gap-rail='end']::after {
+  display: block;
+  top: calc(-1 * var(--leaderboard-row-gap, 0.75rem) / 2);
+  bottom: 50%;
 }
 
 .root:hover {
@@ -110,6 +143,42 @@
   transition: width 240ms ease-out;
 }
 
+.gapMarker {
+  position: absolute;
+  top: calc(-1 * var(--leaderboard-row-gap, 0.75rem) / 2);
+  left: calc(100% + (var(--leaderboard-gap-gutter, 4rem) / 2));
+  z-index: 3;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 3.25rem;
+  height: 2.25rem;
+  padding: 0 var(--ui-space-xs);
+  border: 1px solid rgba(248, 113, 113, 0.22);
+  border-radius: var(--ui-radius-md);
+  background: rgba(255, 247, 247, 0.96);
+  box-shadow: 0 2px 6px rgba(148, 163, 184, 0.14);
+  color: #dc2626;
+  font-size: 1.25rem;
+  font-variant-numeric: tabular-nums;
+  font-weight: var(--ui-font-weight-bold);
+  line-height: 1;
+  transform: translate(-50%, -50%);
+  white-space: nowrap;
+}
+
+.gapAccessibleText {
+  position: absolute;
+  width: 0.0625rem;
+  height: 0.0625rem;
+  padding: 0;
+  margin: -0.0625rem;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .meterFill {
     transition: none;
@@ -130,6 +199,12 @@
 
   .meter {
     height: 0.75rem;
+  }
+
+  .gapMarker {
+    min-width: 2.875rem;
+    height: 2rem;
+    font-size: 1.05rem;
   }
 }
 
@@ -179,5 +254,13 @@
 
   .meter {
     height: 0.75rem;
+  }
+
+  .gapMarker {
+    min-width: 2.5rem;
+    height: 1.75rem;
+    padding: 0 var(--ui-space-2xs);
+    border-radius: var(--ui-radius-sm);
+    font-size: 1rem;
   }
 }

--- a/src/components/LeaderboardRow.tsx
+++ b/src/components/LeaderboardRow.tsx
@@ -11,13 +11,22 @@ type LeaderboardRowTone = {
   meterShadow: string;
 };
 
+export type GapRailPosition = 'start' | 'middle' | 'end';
+
 type LeaderboardRowProps = {
   rank: number;
   teamName: string;
   pingas: number;
   maxPingas: number;
+  gapToPrevious?: number;
+  gapRailPosition?: GapRailPosition;
   ariaRowIndex: number;
 };
+
+const gapFormatter = new Intl.NumberFormat('pt-PT', {
+  maximumFractionDigits: 0,
+  useGrouping: true,
+});
 
 const getTone = (rank: number): LeaderboardRowTone => {
   switch (rank) {
@@ -81,6 +90,8 @@ export function LeaderboardRow({
   teamName,
   pingas,
   maxPingas,
+  gapToPrevious,
+  gapRailPosition,
   ariaRowIndex,
 }: LeaderboardRowProps) {
   const safePingas = Number.isFinite(pingas) ? Math.max(0, Math.floor(pingas)) : 0;
@@ -89,6 +100,16 @@ export function LeaderboardRow({
   const isReferenceValue = safeMax > 0 && safePingas === safeMax;
   const roundedFillPercent = isReferenceValue ? 100 : Math.min(99, Math.round(fillPercent));
   const tone = getTone(rank);
+  const safeGap =
+    gapToPrevious === undefined || !Number.isFinite(gapToPrevious)
+      ? undefined
+      : Math.max(0, Math.floor(gapToPrevious));
+  const visibleGap =
+    safeGap === undefined ? undefined : safeGap === 0 ? '0' : `−${gapFormatter.format(safeGap)}`;
+  const accessibleGap =
+    safeGap === undefined
+      ? undefined
+      : `Diferença para a equipa imediatamente acima: ${safeGap} ${safeGap === 1 ? 'pinga' : 'pingas'}`;
 
   const style = {
     '--row-fill-width': `${fillPercent}%`,
@@ -114,6 +135,7 @@ export function LeaderboardRow({
       aria-rowindex={ariaRowIndex}
       className={styles.root}
       data-testid="leaderboard-row"
+      data-gap-rail={gapRailPosition}
       style={style}
     >
       <div role="cell" className={styles.rankCell}>
@@ -125,6 +147,7 @@ export function LeaderboardRow({
         <span className={styles.teamName} title={teamName}>
           {teamName}
         </span>
+        {accessibleGap ? <span className={styles.gapAccessibleText}>{accessibleGap}</span> : null}
       </div>
       <div role="cell" className={styles.meterCell}>
         <div
@@ -138,6 +161,11 @@ export function LeaderboardRow({
           <div className={styles.meterFill} aria-hidden="true" />
         </div>
       </div>
+      {visibleGap !== undefined ? (
+        <span className={styles.gapMarker} data-testid="leaderboard-gap" aria-hidden="true">
+          {visibleGap}
+        </span>
+      ) : null}
     </div>
   );
 }

--- a/src/pages/Leaderboard.module.css
+++ b/src/pages/Leaderboard.module.css
@@ -103,6 +103,7 @@
 }
 
 .tableCard {
+  --leaderboard-gap-gutter: 5rem;
   gap: var(--ui-space-md);
   min-width: 0;
   border-radius: var(--ui-radius-lg);
@@ -149,6 +150,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--ui-space-sm);
+  width: calc(100% - var(--leaderboard-gap-gutter));
 }
 
 .skeletonRow {
@@ -201,6 +203,7 @@
   --leaderboard-column-gap: var(--ui-space-md);
   --leaderboard-row-height: 5rem;
   --leaderboard-row-gap: 0.75rem;
+  --leaderboard-gap-gutter: 5rem;
   display: flex;
   flex-direction: column;
   gap: var(--ui-space-sm);
@@ -244,6 +247,7 @@
   box-shadow: none;
   border: 1px solid rgba(148, 163, 184, 0.22);
   min-width: 0;
+  width: calc(100% - var(--leaderboard-gap-gutter));
 }
 
 .headerCell {
@@ -275,6 +279,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--leaderboard-row-gap, 0.75rem);
+  width: calc(100% - var(--leaderboard-gap-gutter));
   transform: translateY(0);
   will-change: transform;
 }
@@ -283,12 +288,14 @@
   display: flex;
   flex-direction: column;
   gap: var(--leaderboard-row-gap, 0.75rem);
+  width: calc(100% - var(--leaderboard-gap-gutter));
 }
 
 .displayPinnedList {
   display: flex;
   flex-direction: column;
   gap: var(--leaderboard-row-gap, 0.75rem);
+  width: calc(100% - var(--leaderboard-gap-gutter));
 }
 
 .visuallyHidden {
@@ -376,6 +383,7 @@
       minmax(0, 1.5fr);
     --leaderboard-row-height: 2.75rem;
     --leaderboard-row-gap: 0.125rem;
+    --leaderboard-gap-gutter: 4.5rem;
   }
 
   .tableHeaderMeta h2 {
@@ -429,6 +437,7 @@
 }
 
 .displayPage .tableCard {
+  --leaderboard-gap-gutter: 5rem;
   padding: var(--ui-space-lg);
   gap: var(--ui-space-sm);
   border-radius: var(--ui-radius-md);
@@ -439,6 +448,7 @@
     minmax(18rem, 1.42fr);
   --leaderboard-row-height: 3rem;
   --leaderboard-row-gap: 0.3125rem;
+  --leaderboard-gap-gutter: 5rem;
 }
 
 .displayPage .skeletonValue {
@@ -513,6 +523,7 @@
   }
 
   .tableCard {
+    --leaderboard-gap-gutter: 3.75rem;
     padding: var(--ui-space-md);
     border-radius: var(--ui-radius-md);
   }
@@ -542,6 +553,7 @@
     --leaderboard-column-gap: var(--ui-space-sm);
     --leaderboard-row-height: 4rem;
     --leaderboard-row-gap: 0.4375rem;
+    --leaderboard-gap-gutter: 3.75rem;
   }
 
   .headerRow {

--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -7,7 +7,7 @@ import { observeSponsors, type Sponsor } from '../services/sponsors.service';
 import { Card, Page, Section, Stack, Text } from '../ui';
 import styles from './Leaderboard.module.css';
 
-import { LeaderboardRow } from '../components/LeaderboardRow';
+import { LeaderboardRow, type GapRailPosition } from '../components/LeaderboardRow';
 
 const DEFAULT_ROW_METRICS = { height: 80, gap: 12 };
 const LAPTOP_ROW_METRICS = { height: 44, gap: 2 };
@@ -31,6 +31,11 @@ type LeaderboardTeam = {
   id: string;
   name: string;
   pingas: number;
+};
+
+type LeaderboardTeamWithGap = LeaderboardTeam & {
+  gapToPrevious?: number;
+  gapRailPosition?: GapRailPosition;
 };
 
 type ObserveLeaderboard = (callback: (teams: ServiceTeam[]) => void) => () => void;
@@ -285,37 +290,59 @@ export default function Leaderboard({ displayMode = false }: LeaderboardProps = 
     };
   }, [displayMode, teams.length]);
 
+  const teamsWithGaps = useMemo<LeaderboardTeamWithGap[]>(() => {
+    const railTeamCount = Math.min(teams.length, DISPLAY_PINNED_ROWS);
+
+    return teams.map((team, index) => {
+      const isGapVisible = index > 0 && index < DISPLAY_PINNED_ROWS;
+      const gapToPrevious = isGapVisible
+        ? Math.max(0, teams[index - 1].pingas - team.pingas)
+        : undefined;
+
+      let gapRailPosition: GapRailPosition | undefined;
+      if (index < railTeamCount) {
+        gapRailPosition = index === 0 ? 'start' : index === railTeamCount - 1 ? 'end' : 'middle';
+      }
+
+      return {
+        ...team,
+        gapToPrevious,
+        gapRailPosition,
+      };
+    });
+  }, [teams]);
+
   const virtualState = useMemo(() => {
     if (!shouldVirtualize) {
       return {
         startIndex: 0,
-        items: teams,
+        items: teamsWithGaps,
         offset: 0,
-        totalHeight: getRowsetHeight(teams.length, rowMetrics.height, rowMetrics.gap),
+        totalHeight: getRowsetHeight(teamsWithGaps.length, rowMetrics.height, rowMetrics.gap),
       };
     }
 
     const safeScrollTop = Math.max(0, scrollTop);
     const estimateIndex = Math.floor(safeScrollTop / rowStride);
     const startIndex = Math.max(0, estimateIndex - BUFFER);
-    const endIndex = Math.min(teams.length, startIndex + MAX_RENDERED_ROWS);
+    const endIndex = Math.min(teamsWithGaps.length, startIndex + MAX_RENDERED_ROWS);
     const offset = startIndex * rowStride;
 
     return {
       startIndex,
-      items: teams.slice(startIndex, endIndex),
+      items: teamsWithGaps.slice(startIndex, endIndex),
       offset,
-      totalHeight: getRowsetHeight(teams.length, rowMetrics.height, rowMetrics.gap),
+      totalHeight: getRowsetHeight(teamsWithGaps.length, rowMetrics.height, rowMetrics.gap),
     };
-  }, [rowMetrics.gap, rowMetrics.height, rowStride, scrollTop, shouldVirtualize, teams]);
+  }, [rowMetrics.gap, rowMetrics.height, rowStride, scrollTop, shouldVirtualize, teamsWithGaps]);
 
   const maxPingas = useMemo(
-    () => teams.reduce((max, team) => (team.pingas > max ? team.pingas : max), 0),
-    [teams]
+    () => teamsWithGaps.reduce((max, team) => (team.pingas > max ? team.pingas : max), 0),
+    [teamsWithGaps]
   );
 
-  const displayPinnedTeams = displayMode ? teams.slice(0, DISPLAY_PINNED_ROWS) : [];
-  const displayScrollableTeams = displayMode ? teams.slice(DISPLAY_PINNED_ROWS) : [];
+  const displayPinnedTeams = displayMode ? teamsWithGaps.slice(0, DISPLAY_PINNED_ROWS) : [];
+  const displayScrollableTeams = displayMode ? teamsWithGaps.slice(DISPLAY_PINNED_ROWS) : [];
 
   const leaderboardSponsors = useMemo(
     () => (sponsorStatus === 'loaded' ? sponsors : []),
@@ -420,7 +447,7 @@ export default function Leaderboard({ displayMode = false }: LeaderboardProps = 
                     className={styles.tableSurface}
                     role="table"
                     aria-label={tableAriaLabel}
-                    aria-rowcount={teams.length + 1}
+                    aria-rowcount={teamsWithGaps.length + 1}
                     aria-colcount={3}
                     aria-busy={!isLoaded}
                   >
@@ -456,6 +483,8 @@ export default function Leaderboard({ displayMode = false }: LeaderboardProps = 
                                   teamName={team.name}
                                   pingas={team.pingas}
                                   maxPingas={maxPingas}
+                                  gapToPrevious={team.gapToPrevious}
+                                  gapRailPosition={team.gapRailPosition}
                                   ariaRowIndex={index + 2}
                                 />
                               ))}
@@ -473,6 +502,8 @@ export default function Leaderboard({ displayMode = false }: LeaderboardProps = 
                                     teamName={team.name}
                                     pingas={team.pingas}
                                     maxPingas={maxPingas}
+                                    gapToPrevious={team.gapToPrevious}
+                                    gapRailPosition={team.gapRailPosition}
                                     ariaRowIndex={index + DISPLAY_PINNED_ROWS + 2}
                                   />
                                 ))}
@@ -497,6 +528,8 @@ export default function Leaderboard({ displayMode = false }: LeaderboardProps = 
                                   teamName={team.name}
                                   pingas={team.pingas}
                                   maxPingas={maxPingas}
+                                  gapToPrevious={team.gapToPrevious}
+                                  gapRailPosition={team.gapRailPosition}
                                   ariaRowIndex={virtualState.startIndex + index + 2}
                                 />
                               ))}
@@ -504,13 +537,15 @@ export default function Leaderboard({ displayMode = false }: LeaderboardProps = 
                           </div>
                         ) : (
                           <div className={styles.fullList} role="presentation">
-                            {teams.map((team, index) => (
+                            {teamsWithGaps.map((team, index) => (
                               <LeaderboardRow
                                 key={team.id}
                                 rank={index + 1}
                                 teamName={team.name}
                                 pingas={team.pingas}
                                 maxPingas={maxPingas}
+                                gapToPrevious={team.gapToPrevious}
+                                gapRailPosition={team.gapRailPosition}
                                 ariaRowIndex={index + 2}
                               />
                             ))}

--- a/src/pages/__tests__/LeaderboardPage.test.tsx
+++ b/src/pages/__tests__/LeaderboardPage.test.tsx
@@ -141,6 +141,62 @@ describe('Leaderboard page', () => {
     expect(screen.queryByText('56')).not.toBeInTheDocument();
   });
 
+  it('shows top-five gaps to the immediately preceding team', async () => {
+    observeLeaderboardMock.mockImplementation((callback) => {
+      callback([
+        { id: 'leader', name: 'Leader Squad', pingas: 120 },
+        { id: 'second', name: 'Second Squad', pingas: 119 },
+        { id: 'third', name: 'Third Squad', pingas: 119 },
+        { id: 'fourth', name: 'Fourth Squad', pingas: 100 },
+        { id: 'fifth', name: 'Fifth Squad', pingas: 40 },
+        { id: 'sixth', name: 'Sixth Squad', pingas: 0 },
+      ]);
+      return vi.fn();
+    });
+
+    renderLeaderboard();
+
+    const rows = await screen.findAllByTestId('leaderboard-row');
+    const gaps = screen.getAllByTestId('leaderboard-gap');
+
+    expect(gaps.map((gap) => gap.textContent)).toEqual(['−1', '0', '−19', '−60']);
+    expect(rows[0]).not.toHaveTextContent('Diferença para a equipa');
+    expect(rows[1]).toHaveTextContent('Diferença para a equipa imediatamente acima: 1 pinga');
+    expect(rows[2]).toHaveTextContent('Diferença para a equipa imediatamente acima: 0 pingas');
+    expect(rows[4]).toHaveTextContent('Diferença para a equipa imediatamente acima: 60 pingas');
+    expect(rows[5]).not.toHaveTextContent('Diferença para a equipa');
+    expect(rows.map((row) => row.getAttribute('data-gap-rail'))).toEqual([
+      'start',
+      'middle',
+      'middle',
+      'middle',
+      'end',
+      null,
+    ]);
+  });
+
+  it('ends the gap rail at the last available team', async () => {
+    observeLeaderboardMock.mockImplementation((callback) => {
+      callback([
+        { id: 'leader', name: 'Leader Squad', pingas: 10 },
+        { id: 'second', name: 'Second Squad', pingas: 5 },
+        { id: 'third', name: 'Third Squad', pingas: 1 },
+      ]);
+      return vi.fn();
+    });
+
+    renderLeaderboard();
+
+    const rows = await screen.findAllByTestId('leaderboard-row');
+
+    expect(screen.getAllByTestId('leaderboard-gap')).toHaveLength(2);
+    expect(rows.map((row) => row.getAttribute('data-gap-rail'))).toEqual([
+      'start',
+      'middle',
+      'end',
+    ]);
+  });
+
   it('renders empty comparison meters without exposing a score', async () => {
     observeLeaderboardMock.mockImplementation((callback) => {
       callback([


### PR DESCRIPTION
## Summary

Promote the latest `develop` changes to `production`.

## Included changes

- Merged PR #54: show the top-five difference to the immediately higher-ranked team.
- Keep the first row blank and render the remaining deltas between rows in a dedicated responsive right-side gutter.
- Support leaderboard, TV mode, and mobile layouts with accessible Portuguese gap descriptions.

## Validation

- `yarn lint`
- `yarn typecheck`
- `yarn test --run` — 21 files / 128 tests passed
- `yarn test:ci` — 21 files / 128 tests passed
- `yarn build`
- Browser validation at 1440×900, 1920×1080 TV mode, and 390×844 mobile
- No horizontal overflow or browser warnings/errors observed

## Release note

This PR promotes the merged leaderboard gap feature from `develop` to `production`.