### PR TITLE
refactor: add breathing room to leaderboard gap markers

### DIFF
--- a/src/components/LeaderboardRow.module.css
+++ b/src/components/LeaderboardRow.module.css
@@ -151,9 +151,10 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 3.25rem;
-  height: 2.25rem;
-  padding: 0 var(--ui-space-xs);
+  min-width: 3.75rem;
+  min-height: 2.75rem;
+  height: auto;
+  padding: var(--ui-space-xs) var(--ui-space-sm);
   border: 1px solid rgba(248, 113, 113, 0.22);
   border-radius: var(--ui-radius-md);
   background: rgba(255, 247, 247, 0.96);
@@ -202,8 +203,9 @@
   }
 
   .gapMarker {
-    min-width: 2.875rem;
-    height: 2rem;
+    min-width: 3.25rem;
+    min-height: 2.25rem;
+    padding: var(--ui-space-2xs) var(--ui-space-xs);
     font-size: 1.05rem;
   }
 }
@@ -257,9 +259,9 @@
   }
 
   .gapMarker {
-    min-width: 2.5rem;
-    height: 1.75rem;
-    padding: 0 var(--ui-space-2xs);
+    min-width: 3rem;
+    min-height: 2.25rem;
+    padding: var(--ui-space-xs) var(--ui-space-sm);
     border-radius: var(--ui-radius-sm);
     font-size: 1rem;
   }

--- a/src/pages/Leaderboard.module.css
+++ b/src/pages/Leaderboard.module.css
@@ -103,7 +103,7 @@
 }
 
 .tableCard {
-  --leaderboard-gap-gutter: 5rem;
+  --leaderboard-gap-gutter: 5.5rem;
   gap: var(--ui-space-md);
   min-width: 0;
   border-radius: var(--ui-radius-lg);
@@ -203,7 +203,7 @@
   --leaderboard-column-gap: var(--ui-space-md);
   --leaderboard-row-height: 5rem;
   --leaderboard-row-gap: 0.75rem;
-  --leaderboard-gap-gutter: 5rem;
+  --leaderboard-gap-gutter: 5.5rem;
   display: flex;
   flex-direction: column;
   gap: var(--ui-space-sm);
@@ -383,7 +383,7 @@
       minmax(0, 1.5fr);
     --leaderboard-row-height: 2.75rem;
     --leaderboard-row-gap: 0.125rem;
-    --leaderboard-gap-gutter: 4.5rem;
+    --leaderboard-gap-gutter: 5rem;
   }
 
   .tableHeaderMeta h2 {
@@ -437,7 +437,7 @@
 }
 
 .displayPage .tableCard {
-  --leaderboard-gap-gutter: 5rem;
+  --leaderboard-gap-gutter: 5.5rem;
   padding: var(--ui-space-lg);
   gap: var(--ui-space-sm);
   border-radius: var(--ui-radius-md);
@@ -448,7 +448,7 @@
     minmax(18rem, 1.42fr);
   --leaderboard-row-height: 3rem;
   --leaderboard-row-gap: 0.3125rem;
-  --leaderboard-gap-gutter: 5rem;
+  --leaderboard-gap-gutter: 5.5rem;
 }
 
 .displayPage .skeletonValue {
@@ -523,7 +523,7 @@
   }
 
   .tableCard {
-    --leaderboard-gap-gutter: 3.75rem;
+    --leaderboard-gap-gutter: 4.5rem;
     padding: var(--ui-space-md);
     border-radius: var(--ui-radius-md);
   }
@@ -553,7 +553,7 @@
     --leaderboard-column-gap: var(--ui-space-sm);
     --leaderboard-row-height: 4rem;
     --leaderboard-row-gap: 0.4375rem;
-    --leaderboard-gap-gutter: 3.75rem;
+    --leaderboard-gap-gutter: 4.5rem;
   }
 
   .headerRow {


### PR DESCRIPTION
## What changed

- Increase the gap marker internal padding and minimum size across desktop, TV, and mobile layouts.
- Add extra right-side gutter space so the marker strip has clear separation from leaderboard rows.
- Preserve the existing between-row positioning and top-five behavior.

## Validation

- yarn lint
- yarn typecheck
- yarn test:ci
- yarn build
- Browser validation at desktop, TV, mobile, and the referenced 613x832 viewport with no overflow, clipping, or browser diagnostics.

This branch is based directly on develop and contains only the two leaderboard CSS module changes.